### PR TITLE
Define short codes and implementation for top bar claims

### DIFF
--- a/.github/workflows/codes-checker.yml
+++ b/.github/workflows/codes-checker.yml
@@ -1,0 +1,26 @@
+name: Check panel short codes
+
+on:
+  pull_request:
+    types: [opened, synchronize]
+    paths: 
+      - 'docs/Panel Codes.md'
+      - 'server/simulations/**'
+      - '.github/workflows/codes-checker.yml'
+      - '.github/workflows/scripts/code-checker.py'
+
+jobs:
+  Check_panel_short_codes:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+      
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.x"
+      
+      - name: Run python script
+        run: python .github/workflows/scripts/code-checker.py 

--- a/.github/workflows/codes-checker.yml
+++ b/.github/workflows/codes-checker.yml
@@ -1,6 +1,15 @@
 name: Check panel short codes
 
 on:
+  push:
+    branches:
+      - '*'
+      - '**'
+    paths:
+      - 'docs/Panel Codes.md'
+      - 'server/simulations/**'
+      - '.github/workflows/codes-checker.yml'
+      - '.github/workflows/scripts/code-checker.py'
   pull_request:
     types: [opened, synchronize]
     paths: 

--- a/.github/workflows/scripts/code-checker.py
+++ b/.github/workflows/scripts/code-checker.py
@@ -4,9 +4,9 @@ import sys
 Docs_Path = 'docs/Panel Codes.md'
 Simulations = 'server/simulations'
 
-DocsCodes = ["DocCodes"]
-SimCodes = ["SimCodes"]
-Errors = ["ErrorList"]
+DocsCodes = ["Codes"] # Keep header same to avoid false errors
+SimCodes = ["Codes"]
+Errors = ["ErrorList:"]
 
 def main():
     ImportDocsCodes()
@@ -24,7 +24,7 @@ def main():
 def ImportDocsCodes():
     with open(Docs_Path, 'r') as Document:
         for Line in Document:
-            if Line[0] == '|' and not 'Code' in Line and not '-' in Line:
+            if Line[0] == '|' and not 'Code' in Line and not '--' in Line: # -- to avoid standard hyphens which would cause false errors
                 Code = Line.split('|')[1].strip()
                 if Code in DocsCodes:
                     Errors.append("Code '{0}' duplicated in docs!".format(Code))
@@ -36,7 +36,7 @@ def ImportJSONCodes():
         with open(os.path.join(Simulations, Filename), 'r') as File:
             for Line in File:
                 if '"code":' in Line: # Slightly cursed method of interpreting json files, but it works
-                    Code = Line.replace(',', '').replace('"', '').strip().split(':')[1]
+                    Code = Line.replace(',', '').replace('"', '').strip().split(':')[1].strip()
                     if Code in SimCodes:
                         Errors.append("Code '{0}' duplicated in sims!".format(Code))
                     else:

--- a/.github/workflows/scripts/code-checker.py
+++ b/.github/workflows/scripts/code-checker.py
@@ -1,0 +1,54 @@
+import os
+import sys
+
+Docs_Path = 'docs/Panel Codes.md'
+Simulations = 'server/simulations'
+
+DocsCodes = ["DocCodes"]
+SimCodes = ["SimCodes"]
+Errors = ["ErrorList"]
+
+def main():
+    ImportDocsCodes()
+    ImportJSONCodes()
+    CompareCodes()
+    
+    for Error in Errors:
+        print(Error)
+        
+    if len(Errors) > 1:
+        sys.exit(1)
+    else:
+        sys.exit(0)
+
+def ImportDocsCodes():
+    with open(Docs_Path, 'r') as Document:
+        for Line in Document:
+            if Line[0] == '|' and not 'Code' in Line and not '-' in Line:
+                Code = Line.split('|')[1].strip()
+                if Code in DocsCodes:
+                    Errors.append("Code '{0}' duplicated in docs!".format(Code))
+                else:
+                    DocsCodes.append(Code)
+
+def ImportJSONCodes():
+    for Filename in os.listdir(Simulations):
+        with open(os.path.join(Simulations, Filename), 'r') as File:
+            for Line in File:
+                if '"code":' in Line: # Slightly cursed method of interpreting json files, but it works
+                    Code = Line.replace(',', '').replace('"', '').strip().split(':')[1]
+                    if Code in SimCodes:
+                        Errors.append("Code '{0}' duplicated in sims!".format(Code))
+                    else:
+                        SimCodes.append(Code)
+    
+def CompareCodes():
+    for Code in DocsCodes:
+        if not Code in SimCodes:
+            Errors.append("Code '{0}' in docs codes not found in sim codes!".format(Code))
+    for Code in SimCodes:
+        if not Code in DocsCodes:
+            Errors.append("Code '{0}' in sim codes not found in docs codes!".format(Code))
+
+if __name__ == '__main__':
+    main()

--- a/docs/Panel Codes.md
+++ b/docs/Panel Codes.md
@@ -36,7 +36,7 @@ The list is sorted alphabetically by sim name.
 | BLN1 | Blackpool North 1 |  |
 | BLN2 | Blackpool North 2 |  |
 | BRW | Weston | ~~Bristol~~ |
-| BR | Bristol |  |
+| BRS | Bristol |  |
 | BRB | Bath |  |
 | BRF | Filton |  |
 | BRA | St Andrews |  |

--- a/docs/Panel Codes.md
+++ b/docs/Panel Codes.md
@@ -40,12 +40,12 @@ The list is sorted alphabetically by sim name.
 | BRB | Bath |  |
 | BRF | Filton |  |
 | BRA | St Andrews |  |
-| CVM | Mill Lane Jn | ~~Calder Valley~~ |
-| CVH | Halifax |  |
-| CVE | Healey Mills |  |
-| CVB | Batley |  |
-| CVR | Milner Royd |  |
-| CVD | Hebden Bridge |  |
+| CAM | Mill Lane Jn | ~~Calder Valley~~ |
+| CAH | Halifax |  |
+| CAE | Healey Mills |  |
+| CAB | Batley |  |
+| CAR | Milner Royd |  |
+| CAD | Hebden Bridge |  |
 | CBS | South | ~~Cambridge~~ |
 | CBC | Station |  |
 | CBN | North |  |
@@ -64,9 +64,9 @@ The list is sorted alphabetically by sim name.
 | CGB | Barry | Cardiff Vale of Glamorgan |
 | CGA | Aberthaw |  |
 | CGC | Cowbridge Road |  |
-| CRA | A (North) | Carlisle |
-| CRB | B (Station) |  |
-| CRC | C (South) |  |
+| CLA | A (North) | Carlisle |
+| CLB | B (Station) |  |
+| CLC | C (South) |  |
 | CC | Cathcart | Cathcart |
 | CS1 | Cowlairs 1 | Central Scotland |
 | CS2 | Cowlairs 2 |  |
@@ -90,14 +90,14 @@ The list is sorted alphabetically by sim name.
 | CEE | Ellesmere Port |  |
 | CEB | Beeston Castle |  |
 | CEM | Mickle Trafford |  |
-| CEH | Helsby |  |
+| CEL | Helsby |  |
 | CEF | Frodsham |  |
 | CEN | Norton |  |
 | CNP | Penzance | Cornwall |
 | CNE | St Erth |  |
 | CNR | Roskear Jn |  |
 | CNT | Truro |  |
-| CNP | Par |  |
+| CNA | Par |  |
 | CNB | St Blazey |  |
 | CNG | Goonbarrow Jn |  |
 | CNW | Lostwithiel |  |
@@ -105,7 +105,7 @@ The list is sorted alphabetically by sim name.
 | CWA | Ascott under Wychwood | ~~Cotswolds~~ |
 | CWM | Moreton in Marsh |  |
 | CWE | Evesham |  |
-| CWN | Norton Jn |  |
+| CWJ | Norton Jn |  |
 | CWS | Worcester Shrub Hill |  |
 | CWT | Worcester Tunnel Jn |  |
 | CWD | Droitwich Spa |  |
@@ -118,7 +118,7 @@ The list is sorted alphabetically by sim name.
 | CRY | Coal Yard |  |
 | CRN | North |  |
 | CRS | South |  |
-| CRW | Steel Works |  |
+| CRK | Steel Works |  |
 | CRB | Basford Hall |  |
 | CRG | Gresty Lane |  |
 | CRA | Salop Goods Jn |  |

--- a/docs/Panel Codes.md
+++ b/docs/Panel Codes.md
@@ -110,8 +110,8 @@ The list is sorted alphabetically by sim name.
 | CWT | Worcester Tunnel Jn |  |
 | CWD | Droitwich Spa |  |
 | CWH | Henwick |  |
-| CWN | Newlands East |  |
-| CWM | Malvern Hills |  |
+| CWN | Newland East |  |
+| CWW | Malvern Wells |  |
 | CWL | Ledbury |  |
 | CV | Coventry | Coventry |
 | CRW | Winsford | Crewe |

--- a/docs/Panel Codes.md
+++ b/docs/Panel Codes.md
@@ -1,0 +1,666 @@
+# Panel codes to panel name and sim
+
+Sim names ~~struck through~~ indicate a simulation that does not exist in SimSig loader format.  
+Panel and sim names are informative and not reflective of internal identification.  
+The list is sorted alphabetically by sim name.  
+
+| Code | Panel Name | Sim Name |
+| -- | ---------- | --- |
+| VICN | North Signals | Victoria Line |
+| VICC | Centre Signals |  |
+| VICS | South Signals |  |
+| VICL | Line Controller |  |
+| AF1 | Workstation 1 | ~~Ashford~~ |
+| AF2 | Workstation 2 |  |
+| AFT | Tonbridge |  |
+| AF3 | Workstation 3 |  |
+| AF4 | Workstation 4 |  |
+| AF5 | Workstation 5 |  |
+| ALR | Alrewas | Aston |
+| LTV | Lichfield Trent Valley |  |
+| AST | Aston |  |
+| BM | Basingstoke | Basingstoke Main |
+| NSS1 | South 1 | Birmingham New Street |
+| NSS2 | South 2 |  |
+| NSC | Centre |  |
+| NSN | North |  |
+| BLS | Salwick | ~~Blackpool~~ |
+| BLK | Kirkham |  |
+| BLP | Poulton |  |
+| BL1 | Blackpool North 1 |  |
+| BL2 | Blackpool North 2 |  |
+| BRW | Weston | ~~Bristol~~ |
+| BR | Bristol |  |
+| BRB | Bath |  |
+| BRF | Filton |  |
+| BRA | St Andrews |  |
+| CVM | Mill Lane Jn | ~~Calder Valley~~ |
+| CVH | Halifax |  |
+| CVE | Healey Mills |  |
+| CVB | Batley |  |
+| CVR | Milner Royd |  |
+| CVD | Hebden Bridge |  |
+| CBS | South | ~~Cambridge~~ |
+| CBC | Station |  |
+| CBN | North |  |
+| CBK | Kings Dyke |  |
+| CBW | Canterbury/Wye ACC | ~~Canterbury~~ |
+| CBF | Folkestone East |  |
+| CDE | East | Cardiff |
+| CDW | West |  |
+| CDT | Taff |  |
+| CDF | St Fagan's |  |
+| CVR | Radyr | Cardiff Valleys |
+| CVA | Abercynon |  |
+| CVH | Heath |  |
+| CVYM | Ystrad Mynach South |  |
+| CVB | Bargoed |  |
+| CGB | Barry | Cardiff Vale of Glamorgan |
+| CGA | Aberthaw |  |
+| CGC | Cowbridge Road |  |
+| CRA | A (North) | Carlisle |
+| CRB | B (Station) |  |
+| CRC | C (South) |  |
+| CC | Cathcart | Cathcart |
+| CS1 | Cowlairs 1 | Central Scotland |
+| CS2 | Cowlairs 2 |  |
+| CSG | Greenhill Jn |  |
+| CSC | Carmuirs East Jn |  |
+| CSL | Larbert North |  |
+| CSH | Grangemouth Jn |  |
+| CSP | Polmont Jn |  |
+| CSF | Fouldubs Jn |  |
+| CSM1 | Stirling Middle South |  |
+| CSM2 | Sirling Middle Kincardine |  |
+| CSN | Sirling North |  |
+| CSD | Dunblane |  |
+| CHG | Greenbank | Cheshire Lines |
+| CHP | Plumley West |  |
+| CHM | Mobberley |  |
+| CHD | Deansgate Jn |  |
+| CHN | Northenden Jn |  |
+| CEC | Chester | Chester |
+| CEH | Hooton |  |
+| CEE | Ellesmere Port |  |
+| CEB | Beeston Castle |  |
+| CEM | Mickle Trafford |  |
+| CEH | Helsby |  |
+| CEF | Frodsham |  |
+| CEN | Norton |  |
+| CNP | Penzance | Cornwall |
+| CNE | St Erth |  |
+| CNR | Roskear Jn |  |
+| CNT | Truro |  |
+| CNP | Par |  |
+| CNB | St Blazey |  |
+| CNG | Goonbarrow Jn |  |
+| CNW | Lostwithiel |  |
+| CNK | Liskeard |  |
+| CWA | Ascott under Wychwood | ~~Cotswolds~~ |
+| CWM | Moreton in Marsh |  |
+| CWE | Evesham |  |
+| CWN | Norton Jn |  |
+| CWS | Worcester Shrub Hill |  |
+| CWT | Worcester Tunnel Jn |  |
+| CWD | Droitwich Spa |  |
+| CWH | Henwick |  |
+| CWN | Newlands East |  |
+| CWM | Malvern Hills |  |
+| CWL | Ledbury |  |
+| CV | Coventry | Coventry |
+| CRW | Winsford | Crewe |
+| CRY | Coal Yard |  |
+| CRN | North |  |
+| CRS | South |  |
+| CRW | Steel Works |  |
+| CRB | Basford Hall |  |
+| CRG | Gresty Lane |  |
+| CRA | Salop Goods Jn |  |
+| CRO | Sorting Sdgs |  |
+| CUA | Arnside | ~~Cumbrian Coast~~ |
+| CUG | Grange over Sands |  |
+| CUU | Ulverston |  |
+| CUD | Dalton Jn |  |
+| CUB | Barrow in Furness |  |
+| CUP | Park South |  |
+| CUK | Askam |  |
+| CUF | Foxfield |  |
+| CUM | Millom |  |
+| CUS | Silecroft |  |
+| CUR | Kirksanton |  |
+| CUL | Limestone Hall |  |
+| CUO | Bootle |  |
+| CUD | Drigg |  |
+| CUN | Sellafield |  |
+| CUE | St Bees |  |
+| CUA | Bransty |  |
+| CU2 | Workington 2 |  |
+| CU3 | Workington 3 |  |
+| CUP | Maryport |  |
+| CUW | Wigton |  |
+| DBW | West | Derby |
+| DBC | Centre |  |
+| DBN | North |  |
+| DBL | Mantle Lane |  |
+| DBM | Moira West |  |
+| DN5 | Panel 5 | Doncaster North |
+| DN4 | Panel 4 |  |
+| DN3 | Panel 3 | Doncaster Station |
+| DN2 | Panel 2 |  |
+| DNC | (Panel 2 common) | (Station/South) |
+| DN1N | Panel 1 North | Doncaster South |
+| DN1S | Panel 1 South |  |
+| DCL | Low Gates | ~~Durham Coast~~ |
+| DCB | Bowesfield |  |
+| DCF | Ferryhill |  |
+| DCR | Ryhope Grange |  |
+| ECL | Lewes | East Coastway |
+| ECT | Newhaven Town |  |
+| ECH | Newhaven Harbour |  |
+| ECB | Berwick |  |
+| ECP | Polegate |  |
+| ECA | Hampden Park |  |
+| ECE | Eastbourne |  |
+| ECW | Pevensey & Westham |  |
+| ECX | Bexhill |  |
+| EKR | Rochester | ~~East Kent~~ |
+| EKC | Cuxton |  |
+| EKW | Wateringbury |  |
+| EH1 | Panel 1 | ~~Eastleigh~~ |
+| EH2 | Panel 2 |  |
+| EH3 | Panel 3 |  |
+| EWC | Claydon L&NE Jn | ~~East-West Rail~~ |
+| EWW | Marston Vale West |  |
+| EWE | Marston Vale East |  |
+| EDH | Halton Jn | Edge Hill |
+| EDR | Runcorn |  |
+| EDM | Monks Sdgs |  |
+| EDF | Fiddlers Ferry |  |
+| EDD | Ditton |  |
+| EDS | Speke Jn |  |
+| EDA | Allerton |  |
+| EDE | Edge Hill |  |
+| EDL | Lime Street |  |
+| EB1 | Panel 1 | Edinburgh |
+| EB2 | Panel 2 |  |
+| EB3 | Panel 3 |  |
+| EB4 | Panel 4 |  |
+| EB5 | Panel 5 |  |
+| EB6 | Panel 6 |  |
+| EBM | Millerhill |  |
+| EL1 | Workstation 1 | ~~East London Line~~ |
+| EL2 | Workstation 2 |  |
+| EXA | Panel A | Exeter |
+| EXB | Panel B |  |
+| EXC | Panel C |  |
+| EXP | Paignton |  |
+| EXE | Exmouth Jn |  |
+| EXR | Crediton |  |
+| FHR | Reading | Feltham |
+| FHW | Wokingham |  |
+| FHA | Ascot |  |
+| FHS | Staines |  |
+| FHH | Hounslow |  |
+| FHT | Twickenham |  |
+| FHR | Strawberry Hill |  |
+| FHB | Barnes |  |
+| GES | Stratford | ~~GEML Inner~~ |
+| GEI | Ilford |  |
+| GGS | Station | ~~Glasgow~~ |
+| GGB | Bridge Street |  |
+| GGP | Polmadie |  |
+| GGM | Muirhouse |  |
+| GGS | Shields |  |
+| GLN | North | ~~Gloucester~~ |
+| GLC | Central |  |
+| GLS | South |  |
+| GSB | Barrhead | ~~Glasgow South West~~ |
+| GSL | Lugton |  |
+| GSK | Kilmarnock |  |
+| GSH | Hurlford |  |
+| GSM | Mauchline |  |
+| GSN | New Cumnock |  |
+| GSC | Kirkconnel |  |
+| GST | Thornhill |  |
+| GSH | Holywood |  |
+| GSD | Dumfries Station |  |
+| GSA | Annan |  |
+| GFE | East | ~~Guildford~~ |
+| GFW | West |  |
+| HGF | Horsforth | ~~Harrogate~~ |
+| HGR | Rigton |  |
+| HGH | Harrogate |  |
+| HGS | Starbeck |  |
+| HGK | Knaresborough |  |
+| HGC | Cattal |  |
+| HGM | Hammerton |  |
+| HGP | Poppleton |  |
+| HSR | Robertsbridge | ~~Hastings~~ |
+| HSB | Bo Peep Jn |  |
+| HSH | Hastings |  |
+| HSY | Rye |  |
+| HFD | Dorrington | Hereford |
+| HFM | Marsh Brook |  |
+| HFC | Craven Arms |  |
+| HFO | Onibury |  |
+| HFB | Bromfield |  |
+| HFW | Woofferton |  |
+| HFE | Leominster |  |
+| HFG | Moreton on Lugg |  |
+| HFH | Hereford |  |
+| HFT | Tram Inn |  |
+| HFI | Pontrilias |  |
+| HFP | Pantyffynnon |  |
+| HFA | Abergavenny |  |
+| HFL | Little Mill Jn |  |
+| HVH | Hazel Grove | Hope Valley |
+| HVC | New Mills Central |  |
+| HVS | New Mills South Jn |  |
+| HVC | Chinley |  |
+| HVE | Edale |  |
+| HVA | Earles Sdgs |  |
+| HVG | Grindleford |  |
+| HVT | Totley Tunnel East |  |
+| HVP | Peak Forest |  |
+| HVG | Great Rocks |  |
+| HVF | Furness Vale |  |
+| HVL | Chapel-En-Le-Frith |  |
+| HVB | Buxton |  |
+| HOH | Horsham | Horsham |
+| HOD | Dorking |  |
+| HUH | Huddersfield | Huddersfield |
+| HUD | Diggle Jn |  |
+| HLG | Goole | ~~Hull~~ |
+| HLB | Goole Bridge |  |
+| HLS | Selby |  |
+| HLB | Brough |  |
+| HLH | Hessle Road |  |
+| HLP | Hull Paragon |  |
+| HCH | Hunts Cross | Hunts Cross |
+| HCW | Warrington Central |  |
+| HCG | Glazebrook East Jn |  |
+| HYL | MROC Liverpool | Huyton & St Helens |
+| HYH | St Helens |  |
+| IVD | Dunkeld | ~~Inverness~~ |
+| IVY | Dyce |  |
+| KXX | Cross | Kings Cross |
+| KXF | Finsbury |  |
+| KXP | Palace |  |
+| KXW | Welwyn |  |
+| KXH | Hitchin |  |
+| LN | Panel 1 | Lancing |
+| LM | Leamington | Leamington Spa & Fenny Compton |
+| LA | Leeds Ardsley | Leeds Ardsley |
+| LSW2 | West 2 | Leeds East/West |
+| LSW1 | West 1 |  |
+| LSE1 | East 1 |  |
+| LSE2 | East 2 |  |
+| LN | Leeds Northwest | Leeds Northwest |
+| LSS | South | ~~Leicester~~ |
+| LSC | Croft |  |
+| LSN | North |  |
+| LSB | Bardon Hill |  |
+| LSF | Frisby Hill |  |
+| LSM | Melton Station |  |
+| LSW | Whissendine |  |
+| LSA | Ashwell |  |
+| LSL | Langham Jn |  |
+| LSO | Oakham LC |  |
+| LSM | Manton Jn |  |
+| LSK | Ketton |  |
+| LSU | Uffington & Barnack |  |
+| LCS | South | ~~Lincoln~~ |
+| LCE | East |  |
+| LCC | City |  |
+| LCW | West |  |
+| LCSB | Swinderby |  |
+| LCLG | Langworth |  |
+| LCWB | Wickenby |  |
+| LCHM | Holton-le-Moor |  |
+| LCAC | Ancaster |  |
+| LCRA | Rauceby |  |
+| LCSW | Sleaford West |  |
+| LCSE | Sleaford East |  |
+| LCHE | Heckington |  |
+| LCHB | Hubberts Bridge |  |
+| LCBW | Boston West Street Jn |  |
+| LCSY | Sibsey |  |
+| LCBJ | Bellwater Jn |  |
+| LCTC | Thorpe Culvert |  |
+| LCWA | Wainfleet |  |
+| LCSK | Skegness |  |
+| LVA | West Anglia | Liverpool Street |
+| LVE | Great Eastern |  |
+| LB1 | Panel 1 | London Bridge |
+| LB2 | Panel 2 |  |
+| LB3 | Panel 3 |  |
+| LB4 | Panel 4 |  |
+| LB5 | Panel 5 |  |
+| LB6 | Panel 6 |  |
+| LB7 | Panel 7 |  |
+| LB8 | Panel 8 |  |
+| LB9 | Panel 9 |  |
+| LTL | London | LTS |
+| LTS | Southend |  |
+| LTT | Tilbury |  |
+| LTC | Crossings |  |
+| MHW | West | ~~Machynlleth~~ |
+| MHE | East |  |
+| MD | Maidstone East | Maidstone East |
+| MED | Dinting | Manchester East |
+| MEG | Guide Bridge |  |
+| MES | Stalybridge |  |
+| MER | Romiley Jn |  |
+| MEM | Ashton Moss North |  |
+| MEB | Baguley Fold Jn |  |
+| MEE | Denton |  |
+| MEA | Ashburys |  |
+| MNW | West | Manchester North |
+| MNE | East |  |
+| MNV | Vitriol Works |  |
+| MNC | Castleton East |  |
+| MNR | Rochdale West |  |
+| MPH | Heald Green | Manchester Piccadilly |
+| MPL | Longsight |  |
+| MPP | Piccadilly |  |
+| MPO | Oxford Road |  |
+| MPW1 | Windsor Bridge 1 |  |
+| MPW2 | Windsor Bridge 2 | |
+| MPC | Crow Nest |  |
+| MS | Manchester South | Manchester South |
+| MC | Macclesfield |  |
+| MBB | Banbury | Marylebone |
+| MBS | Marylebone South |  |
+| MBN | Marylebone North |  |
+| MBB | Bicester-Oxford | |
+| MBL | LUL Area | |
+| MOB | Bedlington | ~~Morpeth~~ |
+| MOM | Morpeth |  |
+| MOA | Alnmouth |  |
+| MOT | Tweedmouth |  |
+| MW1 | Workstation 1 | Motherwell |
+| MW2 | Workstation 2 |  |
+| MW3 | Workstation 3 |  |
+| MW4 | Workstation 4 |  |
+| MW5 | Workstation 5 |  |
+| MW6 | Workstation 6 |  |
+| ESGL | Greenloaning | North East Scotland |
+| ESBF | Blackford |  |
+| ESAH | Auchterarder |  |
+| ESH | Hilton Jn |  |
+| ESP | Perth |  |
+| ESBH | Barnhill |  |
+| ESER | Errol |  |
+| ESLF | Longforgan |  |
+| ESD | Dundee |  |
+| EST | Tay Bridge South |  |
+| ESL | Leuchars |  |
+| ESC | Cupar |  |
+| ESS | Stanley Jn |  |
+| ESCN | Carnoustie |  |
+| ESAB | Arbroath |  |
+| ESI | Inerkeilor |  |
+| ESU | Usan |  |
+| ESM | Montrose North |  |
+| ESCR | Craigo |  |
+| ESLK | Laurencekirk |  |
+| ESCA | Carmont |  |
+| ESSH | Stonehaven |  |
+| ESNH | Newtonhill |  |
+| ESA | Aberdeen |  |
+| WXD | Dee Marsh Jn | North East Wales |
+| WXS | Shotwick Ground Frame |  |
+| WXP | Penyfford |  |
+| WXG | Croes Newydd North Fork |  |
+| WXG | Gobowen North |  |
+| NPS | Severn Tunnel | Newport |
+| NPM | Magor |  |
+| NPS | Station |  |
+| NPP | Park Jn |  |
+| NPU | East Usk |  |
+| NLR | Richmond | ~~North London Line~~ |
+| NLW | Acton Wells Jn |  |
+| NLC | Acton Canal Wharf |  |
+| NLN | Neasden Jn |  |
+| NLD | Dudding Hill Jn |  |
+| NLM | Central Workstation |  |
+| NLE | Eastern Workstation |  |
+| NLT | Temple Mills |  |
+| NLH | Upper Holloway |  |
+| NLP | Harringay Park Jn |  |
+| NLS | South Tottenham Station Jn |  |
+| NWS | Rockcliffe Halt | North Wales Coast |
+| NWO | Holywell Jn |  |
+| NWM | Mostyn |  |
+| NWT | Talacre |  |
+| NWE | Prestatyn |  |
+| NWR | Rhyl |  |
+| NWA | Abergele |  |
+| NWLJ | Llandudno Jn |  |
+| NWL | Llanrwst |  |
+| NWD | Deganwy |  |
+| NWLS | Llandudno |  |
+| NWP | Penmaenmawr |  |
+| NWB | Bangor |  |
+| NWG | Gaerwen |  |
+| NWV | Valley |  |
+| NWH | Holyhead |  |
+| NK1 | North Kent 1 | North Kent |
+| NK2 | North Kent 2 |  |
+| OXF | Oxford | Oxford |
+| OXT | Oxted | Oxted |
+| PDG | Greenford East | ~~Paddington~~ |
+| PD1 | Panel 1 |  |
+| PD2 | Panel 2 |  |
+| PA1 | Panel 1 | Paisley |
+| PA2 | Panel 2 |  |
+| PA3 | Panel 3 |  |
+| PBT | Hitchin-Tempsford | Peterborough |
+| PHB | Little Barford-Stilton |  |
+| PHP | Peterborough |  |
+| PHE | New England |  |
+| PHH | Helpston-Stoke |  |
+| PHCE | Everton G.B. |  |
+| PHCO | Offord & Buckden G.B. |  |
+| PHCM | Holme G.B. |  |
+| PHCP | Helpston G.B. |  |
+| PHCT | Tallington G.B. |  |
+| PLW | West | Plymouth |
+| PLE | East |  |
+| PTA | Panel A | Port Talbot |
+| PTB | Panel B |  |
+| PTC | Panel C |  |
+| PTT | Tondu |  |
+| PTN | Neath & Brecon Jn |  |
+| PNA | Panel A | ~~Preston~~ |
+| PNB | Panel B |  |
+| PNC | Panel C |  |
+| PND | Panel D |  |
+| PNY | Daisyfield |  |
+| PNH | Horrocksford |  |
+| PNM | Midge Hall |  |
+| PNR | Rufford |  |
+| PNL | Bare Lane LC |  |
+| PNF | Carnforth St Jn |  |
+| RD | Reading | ~~Reading~~ |
+| RY | Royston | Royston |
+| RSB | Bletchley | Rugby South |
+| RST | Tring |  |
+| RCN | Northampton | Rugby Centre |
+| RCR | Rugby |  |
+| RNN | Nuneaton | Rugby North |
+| RNT | Trent Valley |  |
+| SB | Salisbury | Salisbury |
+| SLST | South Top | Saltley |
+| SLSB | South Bottom |  |
+| SLC | Centre |  |
+| SLN | North |  |
+| SLS | Stratford |  |
+| SHW | Wirral | Sandhills (Merseyrail) |
+| SHN | Northern |  |
+| SCH | Hellifield | ~~Settle & Carlisle Line~~ |
+| SCS | Settle Jn |  |
+| SCB | Blea Moor |  |
+| SCG | Garsdale |  |
+| SCKS | Kirkby Stephen |  |
+| SCA | Appleby North |  |
+| SCKT | Kirkby Thore |  |
+| SCC | Culgaith |  |
+| SCL | Low House Crossing |  |
+| SCH | Howe & Co Siding |  |
+| SFS | Sheffield | Sheffield |
+| SFR1 | Rotherham 1 |  |
+| SFR2 | Rotherham 2 |  |
+| SFE | Beighton St Jn |  |
+| SFH | Woodhouse Jn |  |
+| SFB | Woodburn Jn |  |
+| SFB | Barnsley |  |
+| SFC | Woolley Coal Sdgs |  |
+| SRU | Sutton Bridge Jn | Shrewsbury |
+| SRE | Severn Bridge Jn |  |
+| SRA | Abbey Foregate |  |
+| SRC | Crewe Jn |  |
+| SRB | Crewe Bank |  |
+| SRH | Harlescott Crossing |  |
+| SRW | Wem |  |
+| SRP | Prees |  |
+| SRU | Whitchurch |  |
+| SRR | Wrenbury |  |
+| SRN | Nantwich |  |
+| SUW | West | Slough |
+| SUE | East |  |
+| SMW | Scunthorpe West | ~~South Humberside~~ |
+| SME | Scunthorpe East |  |
+| SMG | Gainsborough |  |
+| SMB | Barnetby |  |
+| SMU | Ulceby Jn |  |
+| SMM | Grimsby |  |
+| SMI | Immingham |  |
+| STD | Derby Line | Staffordshire |
+| STSN | Stoke North |  |
+| STSS | Stoke South |  |
+| STS | Stafford |  |
+| STC | Colwich |  |
+| SPE1 | Edgeley No 1 | Stockport |
+| SPE2 | Edgeley No 2 |  |
+| SPS1 | Stockport No 1 |  |
+| SPS2 | Stockport No 2 |  |
+| SPH | Heaton Norris Jn |  |
+| SJ | Stourbridge Jn | Stourbridge Jn |
+| SW1 | Wootton Basset/1 | Swindon A & B |
+| SW2 | Swindon/2 |  |
+| SW3 | Didcot/3 |  |
+| TOM | Madeley Jn | Telford & Oxley |
+| TOX | Oxley |  |
+| TB1A | Panel 1A | Three Bridges |
+| TB1B | Panel 1B |  |
+| TB1C | Panel 1C |  |
+| TB2 | Panel 2 |  |
+| TB3 | Panel 3 |  |
+| TB4 | Panel 4 |  |
+| TB5 | Panel 5 |  |
+| TB6 | Panel 6 |  |
+| TBR | Reigate |  |
+| TRT | Tapton Jn | ~~Trent~~ |
+| TRC | Clay Cross |  |
+| TRV | Erewash Valley |  |
+| TRP | Pinxton & Sleights East |  |
+| TRK | Kirkby Summit |  |
+| TRR | Robin Hood |  |
+| TRN | Nottingham |  |
+| TRE | East Nottinghamshire |  |
+| TRT | Trent |  |
+| TRS | Stapleford & Sandiacre |  |
+| TYD | Darlington | Tyneside |
+| TYH | Heighington |  |
+| TYL | Shildon |  |
+| TYG | Gateshead |  |
+| TYN | Newcastle |  |
+| TYS | Sunderland |  |
+| VC1 | Panel 1 | Victoria Central |
+| VC2A | Panel 2A |  |
+| VC2B | Panel 2B |  |
+| VC3 | Panel 3 |  |
+| VC4 | Panel 4 |  |
+| VE5 | Panel 5 | Victoria South Eastern |
+| VE6 | Panel 6 |  |
+| VE7 | Panel 7 |  |
+| VE8 | Panel 8 |  |
+| VE9 | Panel 9 |  |
+| VE0A | Panel 10A |  |
+| VE0B | Panel 10B |  |
+| WA6 | Walsall 2006 | Walsall |
+| WA9 | Walsall 2019 |  |
+| WAX | Bloxwich |  |
+| WAH | Hednesford |  |
+| WAS | Brereton Sdgs |  |
+| WAB | Bescot |  |
+| WRN | North | Warrington |
+| WRM | Middle |  |
+| WRS | South |  |
+| WRJ | Arpley Jn |  |
+| WRA | Astley |  |
+| WRE | Eccles |  |
+| WJ | Watford Jn | Watford Jn |
+| WMW | Wembley | Wembley Mainline |
+| WML | Willesden |  |
+| WMC | Camden |  |
+| WME | Euston |  |
+| WS | Wembley Suburban | Wembley Suburban |
+| WAK | Hackney | West Anglia |
+| WAB | Brimsdown |  |
+| WAR | Harlow |  |
+| WCB | Billingshurst | ~~West Coastway~~ |
+| WCL | Lancing Panel 2 |  |
+| WH1 | Panel 1 | West Hampstead |
+| WH2 | Panel 2 |  |
+| WH3 | Panel 3 |  |
+| WH4 | Panel 4 |  |
+| BWH | Honiton | ~~Basingstoke WoE~~ |
+| BWC | Chard Jn |  |
+| BWY | Yeovil Jn |  |
+| BWP | Yeovil Pen Mill |  |
+| BWT | Templecombe |  |
+| BWG | Gillingham |  |
+| WWP | Pembrey | ~~West Wales~~ |
+| WWK | Kidwelly |  |
+| WWF | Ferryside |  |
+| WWC | Carmarthen Jn |  |
+| WWW | Whitland |  |
+| WWB | Clarbeston Rd |  |
+| WYH | Horbury Jn | West Yorkshire |
+| WYW | Wakefield Kirkgate |  |
+| WYC | Castleford |  |
+| WYP | Prince of Wales & Cutsyke |  |
+| WYF | Ferrybridge |  |
+| WYM | Milford |  |
+| WYS | Milford West Sdgs |  |
+| WBR | Reading Newbury | Westbury |
+| WBA | Panel A |  |
+| WBB | Panel B |  |
+| WIW | Wigan Wallgate | Wigan Wallgate |
+| WIR | Rainford Jn |  |
+| WIP | Parbold |  |
+| WIB | Burscough Bridge Jn |  |
+| WI1 | Panel 1 | Wimbledon |
+| WI2 | Panel 2 |  |
+| WI3 | Panel 3 |  |
+| WI4 | Panel 4 |  |
+| WIC | Clapham Yard |  |
+| WOS | Surbiton | Woking |
+| WOW | Working |  |
+| WOA | Aldershot |  |
+| WM | Wolverhampton | Wolverhampton |
+| WST | Thrumpton | ~~Worksop~~ |
+| WSW | Worksop |  |
+| WSM | Maltby Colliery |  |
+| WSK | Kiveton Park |  |
+| WSE | Elmton & Creswell |  |
+| WSS | Shirebrook Jn |  |
+| WSC | Clipstone |  |
+| WSL | Thoresby Colliery Jn |  |
+| YR1 | Workstation 1 | ~~Yoker~~ |
+| YR2 | Workstation 2 |  |
+| YKN | North | York |
+| YKS | South |  |
+| YKG | Gascoigne Wood |  |

--- a/docs/Panel Codes.md
+++ b/docs/Panel Codes.md
@@ -20,6 +20,12 @@ The list is sorted alphabetically by sim name.
 | LTV | Lichfield Trent Valley |  |
 | AST | Aston |  |
 | BM | Basingstoke | Basingstoke Main |
+| BWH | Honiton | ~~Basingstoke WoE~~ |
+| BWC | Chard Jn |  |
+| BWY | Yeovil Jn |  |
+| BWP | Yeovil Pen Mill |  |
+| BWT | Templecombe |  |
+| BWG | Gillingham |  |
 | NSS1 | South 1 | Birmingham New Street |
 | NSS2 | South 2 |  |
 | NSC | Centre |  |
@@ -616,12 +622,6 @@ The list is sorted alphabetically by sim name.
 | WH2 | Panel 2 |  |
 | WH3 | Panel 3 |  |
 | WH4 | Panel 4 |  |
-| BWH | Honiton | ~~Basingstoke WoE~~ |
-| BWC | Chard Jn |  |
-| BWY | Yeovil Jn |  |
-| BWP | Yeovil Pen Mill |  |
-| BWT | Templecombe |  |
-| BWG | Gillingham |  |
 | WWP | Pembrey | ~~West Wales~~ |
 | WWK | Kidwelly |  |
 | WWF | Ferryside |  |

--- a/docs/Panel Codes.md
+++ b/docs/Panel Codes.md
@@ -260,8 +260,8 @@ The list is sorted alphabetically by sim name.
 | HFA | Abergavenny |  |
 | HFL | Little Mill Jn |  |
 | HVH | Hazel Grove | Hope Valley |
-| HVC | New Mills Central |  |
-| HVS | New Mills South Jn |  |
+| HVNC | New Mills Central |  |
+| HVNS | New Mills South Jn |  |
 | HVC | Chinley |  |
 | HVE | Edale |  |
 | HVA | Earles Sdgs |  |

--- a/docs/Panel Codes.md
+++ b/docs/Panel Codes.md
@@ -161,11 +161,11 @@ The list is sorted alphabetically by sim name.
 | DCF | Ferryhill |  |
 | DCR | Ryhope Grange |  |
 | ECL | Lewes | East Coastway |
-| ECT | Newhaven Town |  |
-| ECH | Newhaven Harbour |  |
+| ECNT | Newhaven Town |  |
+| ECNH | Newhaven Harbour |  |
 | ECB | Berwick |  |
 | ECP | Polegate |  |
-| ECA | Hampden Park |  |
+| ECH | Hampden Park |  |
 | ECE | Eastbourne |  |
 | ECW | Pevensey & Westham |  |
 | ECX | Bexhill |  |

--- a/docs/Panel Codes.md
+++ b/docs/Panel Codes.md
@@ -136,13 +136,13 @@ The list is sorted alphabetically by sim name.
 | CUR | Kirksanton |  |
 | CUL | Limestone Hall |  |
 | CUO | Bootle |  |
-| CUD | Drigg |  |
+| CUI | Drigg |  |
 | CUN | Sellafield |  |
 | CUE | St Bees |  |
-| CUA | Bransty |  |
-| CU2 | Workington 2 |  |
-| CU3 | Workington 3 |  |
-| CUP | Maryport |  |
+| CUT | Bransty |  |
+| CUW2 | Workington 2 |  |
+| CUW3 | Workington 3 |  |
+| CUY | Maryport |  |
 | CUW | Wigton |  |
 | DBW | West | Derby |
 | DBC | Centre |  |

--- a/docs/Panel Codes.md
+++ b/docs/Panel Codes.md
@@ -33,8 +33,8 @@ The list is sorted alphabetically by sim name.
 | BLS | Salwick | ~~Blackpool~~ |
 | BLK | Kirkham |  |
 | BLP | Poulton |  |
-| BL1 | Blackpool North 1 |  |
-| BL2 | Blackpool North 2 |  |
+| BLN1 | Blackpool North 1 |  |
+| BLN2 | Blackpool North 2 |  |
 | BRW | Weston | ~~Bristol~~ |
 | BR | Bristol |  |
 | BRB | Bath |  |

--- a/docs/Panel Codes.md
+++ b/docs/Panel Codes.md
@@ -287,7 +287,7 @@ The list is sorted alphabetically by sim name.
 | HCG | Glazebrook East Jn |  |
 | HYL | MROC Liverpool | Huyton & St Helens |
 | HYH | St Helens |  |
-| IVD | Dunkeld | ~~Inverness~~ |
+| IVK | Dunkeld | ~~Inverness~~ |
 | IVY | Dyce |  |
 | KXX | Cross | Kings Cross |
 | KXF | Finsbury |  |

--- a/docs/Panel Codes.md
+++ b/docs/Panel Codes.md
@@ -221,7 +221,7 @@ Reserved codes:
 | GDD | Guildford | Guildford |
 | GDF | Farncombe |  |
 | GDH | Haslemere |  |
-| GHP | Petersfield |  |
+| GDP | Petersfield |  |
 | GES | Stratford | ~~GEML Inner~~ |
 | GEI | Ilford |  |
 | GGS | Station | ~~Glasgow~~ |
@@ -243,8 +243,6 @@ Reserved codes:
 | GSY | Holywood |  |
 | GSD | Dumfries Station |  |
 | GSA | Annan |  |
-| GFE | East | ~~Guildford~~ |
-| GFW | West |  |
 | HCH | Hunts Cross | Hunts Cross |
 | HCW | Warrington Central |  |
 | HCG | Glazebrook East Jn |  |

--- a/docs/Panel Codes.md
+++ b/docs/Panel Codes.md
@@ -216,7 +216,7 @@ Reserved codes:
 | FHS | Staines |  |
 | FHH | Hounslow |  |
 | FHT | Twickenham |  |
-| FHR | Strawberry Hill |  |
+| FHL | Strawberry Hill |  |
 | FHB | Barnes |  |
 | GES | Stratford | ~~GEML Inner~~ |
 | GEI | Ilford |  |
@@ -224,7 +224,7 @@ Reserved codes:
 | GGB | Bridge Street |  |
 | GGP | Polmadie |  |
 | GGM | Muirhouse |  |
-| GGS | Shields |  |
+| GGH | Shields |  |
 | GLN | North | ~~Gloucester~~ |
 | GLC | Central |  |
 | GLS | South |  |
@@ -236,7 +236,7 @@ Reserved codes:
 | GSN | New Cumnock |  |
 | GSC | Kirkconnel |  |
 | GST | Thornhill |  |
-| GSH | Holywood |  |
+| GSY | Holywood |  |
 | GSD | Dumfries Station |  |
 | GSA | Annan |  |
 | GFE | East | ~~Guildford~~ |
@@ -276,7 +276,7 @@ Reserved codes:
 | HVG | Grindleford |  |
 | HVT | Totley Tunnel East |  |
 | HVP | Peak Forest |  |
-| HVG | Great Rocks |  |
+| HVR | Great Rocks |  |
 | HVF | Furness Vale |  |
 | HVL | Chapel-En-Le-Frith |  |
 | HVB | Buxton |  |
@@ -287,7 +287,7 @@ Reserved codes:
 | HLG | Goole | ~~Hull~~ |
 | HLB | Goole Bridge |  |
 | HLS | Selby |  |
-| HLB | Brough |  |
+| HLR | Brough |  |
 | HLH | Hessle Road |  |
 | HLP | Hull Paragon |  |
 | HCH | Hunts Cross | Hunts Cross |
@@ -320,7 +320,7 @@ Reserved codes:
 | LSA | Ashwell |  |
 | LSL | Langham Jn |  |
 | LSO | Oakham LC |  |
-| LSM | Manton Jn |  |
+| LST | Manton Jn |  |
 | LSK | Ketton |  |
 | LSU | Uffington & Barnack |  |
 | LCS | South | ~~Lincoln~~ |
@@ -331,6 +331,7 @@ Reserved codes:
 | LCLG | Langworth |  |
 | LCWB | Wickenby |  |
 | LCHM | Holton-le-Moor |  |
+| LCAL | Allington |  |
 | LCAC | Ancaster |  |
 | LCRA | Rauceby |  |
 | LCSW | Sleaford West |  |
@@ -515,7 +516,7 @@ Reserved codes:
 | SCKT | Kirkby Thore |  |
 | SCC | Culgaith |  |
 | SCL | Low House Crossing |  |
-| SCH | Howe & Co Siding |  |
+| SCD | Howe & Co Siding |  |
 | SFS | Sheffield | Sheffield |
 | SFR1 | Rotherham 1 |  |
 | SFR2 | Rotherham 2 |  |
@@ -532,7 +533,7 @@ Reserved codes:
 | SRH | Harlescott Crossing |  |
 | SRW | Wem |  |
 | SRP | Prees |  |
-| SRU | Whitchurch |  |
+| SRT | Whitchurch |  |
 | SRR | Wrenbury |  |
 | SRN | Nantwich |  |
 | SUW | West | Slough |

--- a/docs/Panel Codes.md
+++ b/docs/Panel Codes.md
@@ -218,6 +218,10 @@ Reserved codes:
 | FHT | Twickenham |  |
 | FHL | Strawberry Hill |  |
 | FHB | Barnes |  |
+| GDD | Guildford | Guildford |
+| GDF | Farncombe |  |
+| GDH | Haslemere |  |
+| GHP | Petersfield |  |
 | GES | Stratford | ~~GEML Inner~~ |
 | GEI | Ilford |  |
 | GGS | Station | ~~Glasgow~~ |
@@ -278,6 +282,7 @@ Reserved codes:
 | HSB | Bo Peep Jn |  |
 | HSH | Hastings |  |
 | HSY | Rye |  |
+| HTP | Portsmouth | ~~Havant~~ |
 | HVH | Hazel Grove | Hope Valley |
 | HVNC | New Mills Central |  |
 | HVNS | New Mills South Jn |  |

--- a/docs/Panel Codes.md
+++ b/docs/Panel Codes.md
@@ -518,14 +518,14 @@ The list is sorted alphabetically by sim name.
 | SFR2 | Rotherham 2 |  |
 | SFE | Beighton St Jn |  |
 | SFH | Woodhouse Jn |  |
-| SFB | Woodburn Jn |  |
+| SFD | Woodburn Jn |  |
 | SFB | Barnsley |  |
 | SFC | Woolley Coal Sdgs |  |
 | SRU | Sutton Bridge Jn | Shrewsbury |
 | SRE | Severn Bridge Jn |  |
 | SRA | Abbey Foregate |  |
-| SRC | Crewe Jn |  |
-| SRB | Crewe Bank |  |
+| SRCJ | Crewe Jn |  |
+| SRCB | Crewe Bank |  |
 | SRH | Harlescott Crossing |  |
 | SRW | Wem |  |
 | SRP | Prees |  |

--- a/docs/Panel Codes.md
+++ b/docs/Panel Codes.md
@@ -416,11 +416,11 @@ The list is sorted alphabetically by sim name.
 | WXD | Dee Marsh Jn | North East Wales |
 | WXS | Shotwick Ground Frame |  |
 | WXP | Penyfford |  |
-| WXG | Croes Newydd North Fork |  |
+| WXN | Croes Newydd North Fork |  |
 | WXG | Gobowen North |  |
 | NPS | Severn Tunnel | Newport |
 | NPM | Magor |  |
-| NPS | Station |  |
+| NPC | Station |  |
 | NPP | Park Jn |  |
 | NPU | East Usk |  |
 | NLR | Richmond | ~~North London Line~~ |

--- a/docs/Panel Codes.md
+++ b/docs/Panel Codes.md
@@ -594,7 +594,7 @@ The list is sorted alphabetically by sim name.
 | VE9 | Panel 9 |  |
 | VE0A | Panel 10A |  |
 | VE0B | Panel 10B |  |
-| WA6 | Walsall 2006 | Walsall |
+| WL6 | Walsall 2006 | Walsall |
 | WA9 | Walsall 2019 |  |
 | WAX | Bloxwich |  |
 | WAH | Hednesford |  |
@@ -613,8 +613,8 @@ The list is sorted alphabetically by sim name.
 | WME | Euston |  |
 | WS | Wembley Suburban | Wembley Suburban |
 | WAK | Hackney | West Anglia |
-| WAB | Brimsdown |  |
-| WAR | Harlow |  |
+| WAD | Brimsdown |  |
+| WAL | Harlow |  |
 | WCB | Billingshurst | ~~West Coastway~~ |
 | WCL | Lancing Panel 2 |  |
 | WH1 | Panel 1 | West Hampstead |

--- a/docs/Panel Codes.md
+++ b/docs/Panel Codes.md
@@ -4,6 +4,14 @@ Sim names ~~struck through~~ indicate a simulation that does not exist in SimSig
 Panel and sim names are informative and not reflective of internal identification.  
 The list is sorted alphabetically by sim name.  
 
+Reserved codes:
+  Peterborough:
+    PBCE - Everton G.B.
+    PBCO - Offord & Buckden G.B.
+    PBCM - Holme G.B.
+    PBCP - Helpston G.B.
+    PBCT - Tallington G.B.
+
 | Code | Panel Name | Sim Name |
 | -- | ---------- | --- |
 | VICN | North Signals | Victoria Line |
@@ -465,11 +473,6 @@ The list is sorted alphabetically by sim name.
 | PHP | Peterborough |  |
 | PHE | New England |  |
 | PHH | Helpston-Stoke |  |
-| PHCE | Everton G.B. |  |
-| PHCO | Offord & Buckden G.B. |  |
-| PHCM | Holme G.B. |  |
-| PHCP | Helpston G.B. |  |
-| PHCT | Tallington G.B. |  |
 | PLW | West | Plymouth |
 | PLE | East |  |
 | PTA | Panel A | Port Talbot |

--- a/docs/Panel Codes.md
+++ b/docs/Panel Codes.md
@@ -241,18 +241,9 @@ Reserved codes:
 | GSA | Annan |  |
 | GFE | East | ~~Guildford~~ |
 | GFW | West |  |
-| HGF | Horsforth | ~~Harrogate~~ |
-| HGR | Rigton |  |
-| HGH | Harrogate |  |
-| HGS | Starbeck |  |
-| HGK | Knaresborough |  |
-| HGC | Cattal |  |
-| HGM | Hammerton |  |
-| HGP | Poppleton |  |
-| HSR | Robertsbridge | ~~Hastings~~ |
-| HSB | Bo Peep Jn |  |
-| HSH | Hastings |  |
-| HSY | Rye |  |
+| HCH | Hunts Cross | Hunts Cross |
+| HCW | Warrington Central |  |
+| HCG | Glazebrook East Jn |  |
 | HFD | Dorrington | Hereford |
 | HFM | Marsh Brook |  |
 | HFC | Craven Arms |  |
@@ -267,6 +258,26 @@ Reserved codes:
 | HFP | Pantyffynnon |  |
 | HFA | Abergavenny |  |
 | HFL | Little Mill Jn |  |
+| HGF | Horsforth | ~~Harrogate~~ |
+| HGR | Rigton |  |
+| HGH | Harrogate |  |
+| HGS | Starbeck |  |
+| HGK | Knaresborough |  |
+| HGC | Cattal |  |
+| HGM | Hammerton |  |
+| HGP | Poppleton |  |
+| HLG | Goole | ~~Hull~~ |
+| HLB | Goole Bridge |  |
+| HLS | Selby |  |
+| HLR | Brough |  |
+| HLH | Hessle Road |  |
+| HLP | Hull Paragon |  |
+| HOH | Horsham | Horsham |
+| HOD | Dorking |  |
+| HSR | Robertsbridge | ~~Hastings~~ |
+| HSB | Bo Peep Jn |  |
+| HSH | Hastings |  |
+| HSY | Rye |  |
 | HVH | Hazel Grove | Hope Valley |
 | HVNC | New Mills Central |  |
 | HVNS | New Mills South Jn |  |
@@ -280,19 +291,8 @@ Reserved codes:
 | HVF | Furness Vale |  |
 | HVL | Chapel-En-Le-Frith |  |
 | HVB | Buxton |  |
-| HOH | Horsham | Horsham |
-| HOD | Dorking |  |
 | HUH | Huddersfield | Huddersfield |
 | HUD | Diggle Jn |  |
-| HLG | Goole | ~~Hull~~ |
-| HLB | Goole Bridge |  |
-| HLS | Selby |  |
-| HLR | Brough |  |
-| HLH | Hessle Road |  |
-| HLP | Hull Paragon |  |
-| HCH | Hunts Cross | Hunts Cross |
-| HCW | Warrington Central |  |
-| HCG | Glazebrook East Jn |  |
 | HYL | MROC Liverpool | Huyton & St Helens |
 | HYH | St Helens |  |
 | IVK | Dunkeld | ~~Inverness~~ |

--- a/docs/Panel Codes.md
+++ b/docs/Panel Codes.md
@@ -595,9 +595,9 @@ Reserved codes:
 | VE7 | Panel 7 |  |
 | VE8 | Panel 8 |  |
 | VE9 | Panel 9 |  |
-| VE0A | Panel 10A |  |
-| VE0B | Panel 10B |  |
-| WL6 | Walsall 2006 | Walsall |
+| VE10A | Panel 10A |  |
+| VE10B | Panel 10B |  |
+| WA6 | Walsall 2006 | Walsall |
 | WA9 | Walsall 2019 |  |
 | WAX | Bloxwich |  |
 | WAH | Hednesford |  |

--- a/docs/Panel Codes.md
+++ b/docs/Panel Codes.md
@@ -469,10 +469,10 @@ Reserved codes:
 | PA2 | Panel 2 |  |
 | PA3 | Panel 3 |  |
 | PBT | Hitchin-Tempsford | Peterborough |
-| PHB | Little Barford-Stilton |  |
-| PHP | Peterborough |  |
-| PHE | New England |  |
-| PHH | Helpston-Stoke |  |
+| PBB | Little Barford-Stilton |  |
+| PBS | Peterborough |  |
+| PBE | New England |  |
+| PBH | Helpston-Stoke |  |
 | PLW | West | Plymouth |
 | PLE | East |  |
 | PTA | Panel A | Port Talbot |

--- a/docs/Panel Codes.md
+++ b/docs/Panel Codes.md
@@ -378,7 +378,6 @@ The list is sorted alphabetically by sim name.
 | MBB | Banbury | Marylebone |
 | MBS | Marylebone South |  |
 | MBN | Marylebone North |  |
-| MBB | Bicester-Oxford | |
 | MBL | LUL Area | |
 | MOB | Bedlington | ~~Morpeth~~ |
 | MOM | Morpeth |  |

--- a/docs/Panel Codes.md
+++ b/docs/Panel Codes.md
@@ -294,7 +294,7 @@ The list is sorted alphabetically by sim name.
 | KXP | Palace |  |
 | KXW | Welwyn |  |
 | KXH | Hitchin |  |
-| LN | Panel 1 | Lancing |
+| LC | Panel 1 | Lancing |
 | LM | Leamington | Leamington Spa & Fenny Compton |
 | LA | Leeds Ardsley | Leeds Ardsley |
 | LSW2 | West 2 | Leeds East/West |

--- a/docs/Panel Codes.md
+++ b/docs/Panel Codes.md
@@ -566,7 +566,7 @@ The list is sorted alphabetically by sim name.
 | TB5 | Panel 5 |  |
 | TB6 | Panel 6 |  |
 | TBR | Reigate |  |
-| TRT | Tapton Jn | ~~Trent~~ |
+| TRA | Tapton Jn | ~~Trent~~ |
 | TRC | Clay Cross |  |
 | TRV | Erewash Valley |  |
 | TRP | Pinxton & Sleights East |  |

--- a/server/simulations/ashford.json
+++ b/server/simulations/ashford.json
@@ -4,6 +4,7 @@
 		{
 			"id": "wks1",
 			"name": "Workstation 1 (Orpington & Sevenoaks)",
+			"code": "AF1",
 			"neighbours": [
 				{
 					"simId": "londonbridgeasc",
@@ -26,6 +27,7 @@
 		{
 			"id": "wks2",
 			"name": "Workstation 2 (Tonbridge & Paddock Wood)",
+			"code": "AF2",
 			"neighbours": [
 				{
 					"simId": "ashford",
@@ -52,6 +54,7 @@
 		{
 			"id": "tonbridge",
 			"name": "Tonbridge PSB",
+			"code": "AFT",
 			"neighbours": [
 				{
 					"simId": "ashford",
@@ -66,6 +69,7 @@
 		{
 			"id": "wks3",
 			"name": "Workstation 3 (Ashford-Rye)",
+			"code": "AF3",
 			"neighbours": [
 				{
 					"simId": "ashford",
@@ -80,6 +84,7 @@
 		{
 			"id": "wks4",
 			"name": "Workstation 4 (Ashford)",
+			"code": "AF4",
 			"neighbours": [
 				{
 					"simId": "ashford",
@@ -106,6 +111,7 @@
 		{
 			"id": "wks5",
 			"name": "Workstation 5 (Dollands Moor)",
+			"code": "AF5",
 			"neighbours": [
 				{
 					"simId": "ashford",

--- a/server/simulations/aston.json
+++ b/server/simulations/aston.json
@@ -4,6 +4,7 @@
 		{
 			"id": "aston",
 			"name": "Aston",
+			"code": "AST",
 			"neighbours": [
 				{
 					"simId": "newstreet",
@@ -18,6 +19,7 @@
 		{
 			"id": "lichfieldtv",
 			"name": "Lichfield T.V.",
+			"code": "LTV",
 			"neighbours": [
 				{
 					"simId": "aston",
@@ -36,6 +38,7 @@
 		{
 			"id": "alrewas",
 			"name": "Alrewas",
+			"code": "ALR",
 			"neighbours": [
 				{
 					"simId": "aston",

--- a/server/simulations/basingstoke.json
+++ b/server/simulations/basingstoke.json
@@ -4,6 +4,7 @@
 		{
 			"id": "basingstoke",
 			"name": "Basingstoke",
+			"code": "BM",
 			"neighbours": [
 				{
 					"simId": "eastleigh",

--- a/server/simulations/blackpool.json
+++ b/server/simulations/blackpool.json
@@ -4,6 +4,7 @@
 		{
 			"id": "salwick",
 			"name": "Salwick SB",
+			"code": "BLS",
 			"neighbours": [
 				{
 					"simId": "preston",
@@ -18,6 +19,7 @@
 		{
 			"id": "kirkham",
 			"name": "Kirkham SB",
+			"code": "BLK",
 			"neighbours": [
 				{
 					"simId": "blackpool",
@@ -32,6 +34,7 @@
 		{
 			"id": "poulton",
 			"name": "Poulton SB",
+			"code": "BLP",
 			"neighbours": [
 				{
 					"simId": "blackpool",
@@ -46,6 +49,7 @@
 		{
 			"id": "blackpool1",
 			"name": "Blackpool North No.1 SB",
+			"code": "BLN1",
 			"neighbours": [
 				{
 					"simId": "blackpool",
@@ -60,6 +64,7 @@
 		{
 			"id": "blackpool2",
 			"name": "Blackpool North No.2 SB",
+			"code": "BLN2",
 			"neighbours": [
 				{
 					"simId": "blackpool",

--- a/server/simulations/bristol.json
+++ b/server/simulations/bristol.json
@@ -4,6 +4,7 @@
 		{
 			"id": "weston",
 			"name": "Weston Panel",
+			"code": "BRW",
 			"neighbours": [
 				{
 					"simId": "exeter",
@@ -18,6 +19,7 @@
 		{
 			"id": "bristol",
 			"name": "Bristol Panel",
+			"code": "BRS",
 			"neighbours": [
 				{
 					"simId": "bristol",
@@ -40,6 +42,7 @@
 		{
 			"id": "bath",
 			"name": "Bath Panel",
+			"code": "BRB",
 			"neighbours": [
 				{
 					"simId": "bristol",
@@ -58,6 +61,7 @@
 		{
 			"id": "filton",
 			"name": "Filton Panel",
+			"code": "BRF",
 			"neighbours": [
 				{
 					"simId": "bristol",
@@ -84,6 +88,7 @@
 		{
 			"id": "standrewsjn",
 			"name": "St Andrews Jn SB",
+			"code": "BRA",
 			"neighbours": [
 				{
 					"simId": "bristol",

--- a/server/simulations/caldervalley.json
+++ b/server/simulations/caldervalley.json
@@ -4,6 +4,7 @@
 		{
 			"id": "milllanejn",
 			"name": "Mill Lane Jn SB",
+			"code": "CVM",
 			"neighbours": [
 				{
 					"simId": "leedsew",
@@ -18,6 +19,7 @@
 		{
 			"id": "halifax",
 			"name": "Halifax SB",
+			"code": "CVH",
 			"neighbours": [
 				{
 					"simId": "caldervalley",
@@ -36,6 +38,7 @@
 		{
 			"id": "healeymills",
 			"name": "Healey Mills SB",
+			"code": "CVE",
 			"neighbours": [
 				{
 					"simId": "westyorkshire",
@@ -62,6 +65,7 @@
 		{
 			"id": "batley",
 			"name": "Batley SB",
+			"code": "CVB",
 			"neighbours": [
 				{
 					"simId": "caldervalley",
@@ -76,6 +80,7 @@
 		{
 			"id": "milnerroydjn",
 			"name": "Milner Royd Jn SB",
+			"code": "CVR",
 			"neighbours": [
 				{
 					"simId": "caldervalley",
@@ -94,6 +99,7 @@
 		{
 			"id": "hebdenbridge",
 			"name": "Hebden Bridge SB",
+			"code": "CVD",
 			"neighbours": [
 				{
 					"simId": "caldervalley",

--- a/server/simulations/caldervalley.json
+++ b/server/simulations/caldervalley.json
@@ -4,7 +4,7 @@
 		{
 			"id": "milllanejn",
 			"name": "Mill Lane Jn SB",
-			"code": "CVM",
+			"code": "CAM",
 			"neighbours": [
 				{
 					"simId": "leedsew",
@@ -19,7 +19,7 @@
 		{
 			"id": "halifax",
 			"name": "Halifax SB",
-			"code": "CVH",
+			"code": "CAH",
 			"neighbours": [
 				{
 					"simId": "caldervalley",
@@ -38,7 +38,7 @@
 		{
 			"id": "healeymills",
 			"name": "Healey Mills SB",
-			"code": "CVE",
+			"code": "CAE",
 			"neighbours": [
 				{
 					"simId": "westyorkshire",
@@ -65,7 +65,7 @@
 		{
 			"id": "batley",
 			"name": "Batley SB",
-			"code": "CVB",
+			"code": "CAB",
 			"neighbours": [
 				{
 					"simId": "caldervalley",
@@ -80,7 +80,7 @@
 		{
 			"id": "milnerroydjn",
 			"name": "Milner Royd Jn SB",
-			"code": "CVR",
+			"code": "CAR",
 			"neighbours": [
 				{
 					"simId": "caldervalley",
@@ -99,7 +99,7 @@
 		{
 			"id": "hebdenbridge",
 			"name": "Hebden Bridge SB",
-			"code": "CVD",
+			"code": "CAD",
 			"neighbours": [
 				{
 					"simId": "caldervalley",

--- a/server/simulations/cambridge.json
+++ b/server/simulations/cambridge.json
@@ -4,6 +4,7 @@
 		{
 			"id": "south",
 			"name": "South",
+			"code": "CBS",
 			"neighbours": [
 				{
 					"simId": "warm",
@@ -22,6 +23,7 @@
 		{
 			"id": "station",
 			"name": "Station",
+			"code": "CBC",
 			"neighbours": [
 				{
 					"simId": "cambridge",
@@ -36,6 +38,7 @@
 		{
 			"id": "north",
 			"name": "North",
+			"code": "CBN",
 			"neighbours": [
 				{
 					"simId": "cambridge",
@@ -50,6 +53,7 @@
 		{
 			"id": "kingsdyke",
 			"name": "Kings Dyke SB",
+			"code": "CBK",
 			"neighbours": [
 				{
 					"simId": "cambridge",

--- a/server/simulations/canterbury.json
+++ b/server/simulations/canterbury.json
@@ -4,6 +4,7 @@
 		{
 			"id": "cwacc",
 			"name": "Canterbury/Wye ACC",
+			"code": "CBW",
 			"neighbours": [
 				{
 					"simId": "ashford",
@@ -14,6 +15,7 @@
 		{
 			"id": "folkestoneeast",
 			"name": "Folkestone East SB",
+			"code": "CBF",
 			"neighbours": [
 				{
 					"simId": "ashford",

--- a/server/simulations/cardiff.json
+++ b/server/simulations/cardiff.json
@@ -4,6 +4,7 @@
 		{
 			"id": "east",
 			"name": "East",
+			"code": "CDE",
 			"neighbours": [
 				{
 					"simId": "newport",
@@ -18,6 +19,7 @@
 		{
 			"id": "west",
 			"name": "West",
+			"code": "CDW",
 			"neighbours": [
 				{
 					"simId": "cardiff",
@@ -40,6 +42,7 @@
 		{
 			"id": "taff",
 			"name": "Taff",
+			"code": "CDT",
 			"neighbours": [
 				{
 					"simId": "cardiff",
@@ -62,6 +65,7 @@
 		{
 			"id": "stfagans",
 			"name": "St Fagan's",
+			"code": "CDF",
 			"neighbours": [
 				{
 					"simId": "cardiff",

--- a/server/simulations/cardiffvalleys.json
+++ b/server/simulations/cardiffvalleys.json
@@ -4,6 +4,7 @@
 		{
 			"id": "radyr",
 			"name": "Radyr",
+			"code": "CVR",
 			"neighbours": [
 				{
 					"simId": "cardiff",
@@ -18,6 +19,7 @@
 		{
 			"id": "abercynon",
 			"name": "Abercynon",
+			"code": "CVA",
 			"neighbours": [
 				{
 					"simId": "cardiffvalleys",
@@ -28,6 +30,7 @@
 		{
 			"id": "heathjunction",
 			"name": "Heath Junction",
+			"code": "CVH",
 			"neighbours": [
 				{
 					"simId": "cardiff",
@@ -42,6 +45,7 @@
 		{
 			"id": "ystradmynachsouth",
 			"name": "Ystrad Mynach South",
+			"code": "CVYM",
 			"neighbours": [
 				{
 					"simId": "cardiffvalleys",
@@ -56,6 +60,7 @@
 		{
 			"id": "bargoed",
 			"name": "Bargoed",
+			"code": "CVB",
 			"neighbours": [
 				{
 					"simId": "cardiffvalleys",

--- a/server/simulations/cardiffvog.json
+++ b/server/simulations/cardiffvog.json
@@ -4,6 +4,7 @@
 		{
 			"id": "barry",
 			"name": "Barry",
+			"code": "CGB",
 			"neighbours": [
 				{
 					"simId": "cardiff",
@@ -18,6 +19,7 @@
 		{
 			"id": "aberthaw",
 			"name": "Aberthaw",
+			"code": "CGA",
 			"neighbours": [
 				{
 					"simId": "cardiffvog",
@@ -32,6 +34,7 @@
 		{
 			"id": "cowbridgeroad",
 			"name": "Cowbridge Road",
+			"code": "CGC",
 			"neighbours": [
 				{
 					"simId": "cardiffvog",

--- a/server/simulations/carlisle.json
+++ b/server/simulations/carlisle.json
@@ -4,7 +4,7 @@
 		{
 			"id": "panela",
 			"name": "Panel A",
-			"code": "CRA",
+			"code": "CLA",
 			"neighbours": [
 				{
 					"simId": "motherwell",
@@ -23,7 +23,7 @@
 		{
 			"id": "panelb",
 			"name": "Panel B",
-			"code": "CRB",
+			"code": "CLB",
 			"neighbours": [
 				{
 					"simId": "carlisle",
@@ -46,7 +46,7 @@
 		{
 			"id": "panelc",
 			"name": "Panel C",
-			"code": "CRC",
+			"code": "CLC",
 			"neighbours": [
 				{
 					"simId": "carlisle",

--- a/server/simulations/carlisle.json
+++ b/server/simulations/carlisle.json
@@ -4,6 +4,7 @@
 		{
 			"id": "panela",
 			"name": "Panel A",
+			"code": "CRA",
 			"neighbours": [
 				{
 					"simId": "motherwell",
@@ -22,6 +23,7 @@
 		{
 			"id": "panelb",
 			"name": "Panel B",
+			"code": "CRB",
 			"neighbours": [
 				{
 					"simId": "carlisle",
@@ -44,6 +46,7 @@
 		{
 			"id": "panelc",
 			"name": "Panel C",
+			"code": "CRC",
 			"neighbours": [
 				{
 					"simId": "carlisle",

--- a/server/simulations/cathcart.json
+++ b/server/simulations/cathcart.json
@@ -4,6 +4,7 @@
 		{
 			"id": "cathcart",
 			"name": "Cathcart",
+			"code": "CC",
 			"neighbours": [
 				{
 					"simId": "motherwell",

--- a/server/simulations/cheshirelines.json
+++ b/server/simulations/cheshirelines.json
@@ -4,6 +4,7 @@
 		{
 			"id": "greenbank",
 			"name": "Greenbank",
+			"code": "CHG",
 			"neighbours": [
 				{
 					"simId": "chester",
@@ -26,6 +27,7 @@
 		{
 			"id": "plumleywest",
 			"name": "Plumley West",
+			"code": "CHP",
 			"neighbours": [
 				{
 					"simId": "cheshirelines",
@@ -40,6 +42,7 @@
 		{
 			"id": "mobberley",
 			"name": "Mobberley",
+			"code": "CHM",
 			"neighbours": [
 				{
 					"simId": "cheshirelines",
@@ -54,6 +57,7 @@
 		{
 			"id": "deansgatejn",
 			"name": "Deansgate Jn",
+			"code": "CHD",
 			"neighbours": [
 				{
 					"simId": "cheshirelines",
@@ -68,6 +72,7 @@
 		{
 			"id": "northendenjn",
 			"name": "Northenden Jn",
+			"code": "CHN",
 			"neighbours": [
 				{
 					"simId": "cheshirelines",

--- a/server/simulations/chester.json
+++ b/server/simulations/chester.json
@@ -4,6 +4,7 @@
 		{
 			"id": "chester",
 			"name": "Chester",
+			"code": "CEC",
 			"neighbours": [
 				{
 					"simId": "chester",
@@ -34,6 +35,7 @@
 		{
 			"id": "hooton",
 			"name": "Hooton",
+			"code": "CEH",
 			"neighbours": [
 				{
 					"simId": "sandhills",
@@ -52,6 +54,7 @@
 		{
 			"id": "ellesmereport",
 			"name": "Ellesmere Port",
+			"code": "CEE",
 			"neighbours": [
 				{
 					"simId": "chester",
@@ -66,6 +69,7 @@
 		{
 			"id": "beestoncastle",
 			"name": "Beeston Castle",
+			"code": "CEB",
 			"neighbours": [
 				{
 					"simId": "chester",
@@ -80,6 +84,7 @@
 		{
 			"id": "mickletrafford",
 			"name": "Mickle Trafford",
+			"code": "CEM",
 			"neighbours": [
 				{
 					"simId": "chester",
@@ -98,6 +103,7 @@
 		{
 			"id": "helsby",
 			"name": "Helsby",
+			"code": "CEH",
 			"neighbours": [
 				{
 					"simId": "chester",
@@ -116,6 +122,7 @@
 		{
 			"id": "frodsham",
 			"name": "Frodsham",
+			"code": "CEF",
 			"neighbours": [
 				{
 					"simId": "chester",
@@ -134,6 +141,7 @@
 		{
 			"id": "norton",
 			"name": "Norton",
+			"code": "CEN",
 			"neighbours": [
 				{
 					"simId": "chester",

--- a/server/simulations/chester.json
+++ b/server/simulations/chester.json
@@ -103,7 +103,7 @@
 		{
 			"id": "helsby",
 			"name": "Helsby",
-			"code": "CEH",
+			"code": "CEL",
 			"neighbours": [
 				{
 					"simId": "chester",

--- a/server/simulations/cornwall.json
+++ b/server/simulations/cornwall.json
@@ -60,7 +60,7 @@
 		{
 			"id": "par",
 			"name": "Par",
-			"code": "CNP",
+			"code": "CNA",
 			"neighbours": [
 				{
 					"simId": "cornwall",

--- a/server/simulations/cornwall.json
+++ b/server/simulations/cornwall.json
@@ -4,6 +4,7 @@
 		{
 			"id": "penzance",
 			"name": "Penzance",
+			"code": "CNP",
 			"neighbours": [
 				{
 					"simId": "cornwall",
@@ -14,6 +15,7 @@
 		{
 			"id": "sterth",
 			"name": "St. Erth",
+			"code": "CNE",
 			"neighbours": [
 				{
 					"simId": "cornwall",
@@ -28,6 +30,7 @@
 		{
 			"id": "roskearjn",
 			"name": "Roskear Jn",
+			"code": "CNR",
 			"neighbours": [
 				{
 					"simId": "cornwall",
@@ -42,6 +45,7 @@
 		{
 			"id": "truro",
 			"name": "Truro",
+			"code": "CNT",
 			"neighbours": [
 				{
 					"simId": "cornwall",
@@ -56,6 +60,7 @@
 		{
 			"id": "par",
 			"name": "Par",
+			"code": "CNP",
 			"neighbours": [
 				{
 					"simId": "cornwall",
@@ -74,6 +79,7 @@
 		{
 			"id": "stblazey",
 			"name": "St. Blazey",
+			"code": "CNB",
 			"neighbours": [
 				{
 					"simId": "cornwall",
@@ -88,6 +94,7 @@
 		{
 			"id": "goonbarrowjn",
 			"name": "Goonbarrow Jn",
+			"code": "CNG",
 			"neighbours": [
 				{
 					"simId": "cornwall",
@@ -98,6 +105,7 @@
 		{
 			"id": "lostwithiel",
 			"name": "Lostwithiel",
+			"code": "CNW",
 			"neighbours": [
 				{
 					"simId": "cornwall",
@@ -112,6 +120,7 @@
 		{
 			"id": "liskeard",
 			"name": "Liskeard",
+			"code": "CNK",
 			"neighbours": [
 				{
 					"simId": "cornwall",

--- a/server/simulations/cotswolds.json
+++ b/server/simulations/cotswolds.json
@@ -49,7 +49,7 @@
 		{
 			"id": "nortonjn",
 			"name": "Norton Jn SB",
-			"code": "CWN",
+			"code": "CWJ",
 			"neighbours": [
 				{
 					"simId": "cotswolds",

--- a/server/simulations/cotswolds.json
+++ b/server/simulations/cotswolds.json
@@ -4,6 +4,7 @@
 		{
 			"id": "ascott",
 			"name": "Ascott-under-Wychwood SB",
+			"code": "CWA",
 			"neighbours": [
 				{
 					"simId": "oxford",
@@ -18,6 +19,7 @@
 		{
 			"id": "moreton",
 			"name": "Moreton-in-Marsh SB",
+			"code": "CWM",
 			"neighbours": [
 				{
 					"simId": "cotswolds",
@@ -32,6 +34,7 @@
 		{
 			"id": "evesham",
 			"name": "Evesham SB",
+			"code": "CWE",
 			"neighbours": [
 				{
 					"simId": "cotswolds",
@@ -46,6 +49,7 @@
 		{
 			"id": "nortonjn",
 			"name": "Norton Jn SB",
+			"code": "CWN",
 			"neighbours": [
 				{
 					"simId": "cotswolds",
@@ -64,6 +68,7 @@
 		{
 			"id": "shrubhill",
 			"name": "Worcester Shrub Hill SB",
+			"code": "CWS",
 			"neighbours": [
 				{
 					"simId": "cotswolds",
@@ -82,6 +87,7 @@
 		{
 			"id": "tunneljn",
 			"name": "Worcester Tunnel Jn SB",
+			"code": "CWT",
 			"neighbours": [
 				{
 					"simId": "cotswolds",
@@ -100,6 +106,7 @@
 		{
 			"id": "droitwichspa",
 			"name": "Droitwich Spa SB",
+			"code": "CWD",
 			"neighbours": [
 				{
 					"simId": "cotswolds",
@@ -118,6 +125,7 @@
 		{
 			"id": "henwick",
 			"name": "Henwick SB",
+			"code": "CWH",
 			"neighbours": [
 				{
 					"simId": "cotswolds",
@@ -136,6 +144,7 @@
 		{
 			"id": "newlandeast",
 			"name": "Newland East SB",
+			"code": "CWN",
 			"neighbours": [
 				{
 					"simId": "cotswolds",
@@ -150,6 +159,7 @@
 		{
 			"id": "malvernwells",
 			"name": "Malvern Wells SB",
+			"code": "CWW",
 			"neighbours": [
 				{
 					"simId": "cotswolds",
@@ -164,6 +174,7 @@
 		{
 			"id": "ledbury",
 			"name": "Ledbury SB",
+			"code": "CWL",
 			"neighbours": [
 				{
 					"simId": "cotswolds",

--- a/server/simulations/coventry.json
+++ b/server/simulations/coventry.json
@@ -4,6 +4,7 @@
 		{
 			"id": "coventry",
 			"name": "Coventry",
+			"code": "CV",
 			"neighbours": [
 				{
 					"simId": "newstreet",

--- a/server/simulations/crewe.json
+++ b/server/simulations/crewe.json
@@ -73,7 +73,7 @@
 		{
 			"id": "steelworks",
 			"name": "Steel Works",
-			"code": "CRW",
+			"code": "CRK",
 			"neighbours": [
 				{
 					"simId": "crewe",

--- a/server/simulations/crewe.json
+++ b/server/simulations/crewe.json
@@ -4,6 +4,7 @@
 		{
 			"id": "winsford",
 			"name": "Winsford",
+			"code": "CRW",
 			"neighbours": [
 				{
 					"simId": "edgehill",
@@ -26,6 +27,7 @@
 		{
 			"id": "coalyard",
 			"name": "Coal Yard",
+			"code": "CRY",
 			"neighbours": [
 				{
 					"simId": "crewe",
@@ -44,6 +46,7 @@
 		{
 			"id": "crewepsbnorth",
 			"name": "Crewe PSB North",
+			"code": "CRN",
 			"neighbours": [
 				{
 					"simId": "crewe",
@@ -70,6 +73,7 @@
 		{
 			"id": "steelworks",
 			"name": "Steel Works",
+			"code": "CRW",
 			"neighbours": [
 				{
 					"simId": "crewe",
@@ -84,6 +88,7 @@
 		{
 			"id": "crewepsbsouth",
 			"name": "Crewe PSB South",
+			"code": "CRS",
 			"neighbours": [
 				{
 					"simId": "crewe",
@@ -110,6 +115,7 @@
 		{
 			"id": "basfordhall",
 			"name": "Basford Hall",
+			"code": "CRB",
 			"neighbours": [
 				{
 					"simId": "crewe",
@@ -128,6 +134,7 @@
 		{
 			"id": "grestylane",
 			"name": "Gresty Lane",
+			"code": "CRG",
 			"neighbours": [
 				{
 					"simId": "crewe",
@@ -150,6 +157,7 @@
 		{
 			"id": "salopgoodsjn",
 			"name": "Salop Goods Jn",
+			"code": "CRA",
 			"neighbours": [
 				{
 					"simId": "crewe",
@@ -176,6 +184,7 @@
 		{
 			"id": "sortingsidingsnth",
 			"name": "Sorting Sidings North",
+			"code": "CRO",
 			"neighbours": [
 				{
 					"simId": "crewe",

--- a/server/simulations/cscot.json
+++ b/server/simulations/cscot.json
@@ -4,6 +4,7 @@
 		{
 			"id": "duty1",
 			"name": "Cowlairs - Workstation 1",
+			"code": "CS1",
 			"neighbours": [
 				{
 					"simId": "cscot",
@@ -18,6 +19,7 @@
 		{
 			"id": "duty2",
 			"name": "Cowlairs - Workstation 2",
+			"code": "CS2",
 			"neighbours": [
 				{
 					"simId": "cscot",
@@ -40,6 +42,7 @@
 		{
 			"id": "dutygj",
 			"name": "Greenhill Junction",
+			"code": "CSG",
 			"neighbours": [
 				{
 					"simId": "cscot",
@@ -58,6 +61,7 @@
 		{
 			"id": "dutyce",
 			"name": "Carmuirs East Junction",
+			"code": "CSC",
 			"neighbours": [
 				{
 					"simId": "cscot",
@@ -76,6 +80,7 @@
 		{
 			"id": "dutyln",
 			"name": "Larbert North",
+			"code": "CSL",
 			"neighbours": [
 				{
 					"simId": "cscot",
@@ -94,6 +99,7 @@
 		{
 			"id": "dutygh",
 			"name": "Grangemouth Junction",
+			"code": "CSH",
 			"neighbours": [
 				{
 					"simId": "cscot",
@@ -112,6 +118,7 @@
 		{
 			"id": "dutyp",
 			"name": "Polmont Junction",
+			"code": "CSP",
 			"neighbours": [
 				{
 					"simId": "cscot",
@@ -130,6 +137,7 @@
 		{
 			"id": "dutyfd",
 			"name": "Fouldubs Junction",
+			"code": "CSF",
 			"neighbours": [
 				{
 					"simId": "cscot",
@@ -140,6 +148,7 @@
 		{
 			"id": "dutysm1",
 			"name": "Stirling Middle - South End",
+			"code": "CSM1",
 			"neighbours": [
 				{
 					"simId": "cscot",
@@ -162,6 +171,7 @@
 		{
 			"id": "dutysm2",
 			"name": "Stirling Middle - Kincardine Lines",
+			"code": "CSM2",
 			"neighbours": [
 				{
 					"simId": "cscot",
@@ -184,6 +194,7 @@
 		{
 			"id": "dutysn",
 			"name": "Stirling North",
+			"code": "CSN",
 			"neighbours": [
 				{
 					"simId": "cscot",
@@ -202,6 +213,7 @@
 		{
 			"id": "dutydb",
 			"name": "Dunblane",
+			"code": "CSD",
 			"neighbours": [
 				{
 					"simId": "cscot",

--- a/server/simulations/cumbriancoast.json
+++ b/server/simulations/cumbriancoast.json
@@ -4,6 +4,7 @@
 		{
 			"id": "arnside",
 			"name": "Arnside SB",
+			"code": "CUA",
 			"neighbours": [
 				{
 					"simId": "preston",
@@ -18,6 +19,7 @@
 		{
 			"id": "grangeoversands",
 			"name": "Grange-over-Sands SB",
+			"code": "CUG",
 			"neighbours": [
 				{
 					"simId": "cumbriancoast",
@@ -32,6 +34,7 @@
 		{
 			"id": "ulverston",
 			"name": "Ulverston SB",
+			"code": "CUU",
 			"neighbours": [
 				{
 					"simId": "cumbriancoast",
@@ -46,6 +49,7 @@
 		{
 			"id": "daltonjn",
 			"name": "Dalton Junction SB",
+			"code": "CUD",
 			"neighbours": [
 				{
 					"simId": "cumbriancoast",
@@ -64,6 +68,7 @@
 		{
 			"id": "barrow",
 			"name": "Barrow-in-Furness SB",
+			"code": "CUB",
 			"neighbours": [
 				{
 					"simId": "cumbriancoast",
@@ -78,6 +83,7 @@
 		{
 			"id": "parksouth",
 			"name": "Park South SB",
+			"code": "CUP",
 			"neighbours": [
 				{
 					"simId": "cumbriancoast",
@@ -96,6 +102,7 @@
 		{
 			"id": "askam",
 			"name": "Askam SB",
+			"code": "CUK",
 			"neighbours": [
 				{
 					"simId": "cumbriancoast",
@@ -110,6 +117,7 @@
 		{
 			"id": "foxfield",
 			"name": "Foxfield SB",
+			"code": "CUF",
 			"neighbours": [
 				{
 					"simId": "cumbriancoast",
@@ -124,6 +132,7 @@
 		{
 			"id": "millom",
 			"name": "Millom SB",
+			"code": "CUM",
 			"neighbours": [
 				{
 					"simId": "cumbriancoast",
@@ -138,6 +147,7 @@
 		{
 			"id": "silecroft",
 			"name": "Silecroft SB",
+			"code": "CUS",
 			"neighbours": [
 				{
 					"simId": "cumbriancoast",
@@ -160,6 +170,7 @@
 		{
 			"id": "kirksanton",
 			"name": "Kirksanton LC",
+			"code": "CUR",
 			"neighbours": [
 				{
 					"simId": "cumbriancoast",
@@ -170,6 +181,7 @@
 		{
 			"id": "limestonehall",
 			"name": "Limestone Hall LC",
+			"code": "CUL",
 			"neighbours": [
 				{
 					"simId": "cumbriancoast",
@@ -180,6 +192,7 @@
 		{
 			"id": "bootle",
 			"name": "Bootle SB",
+			"code": "CUO",
 			"neighbours": [
 				{
 					"simId": "cumbriancoast",
@@ -194,6 +207,7 @@
 		{
 			"id": "drigg",
 			"name": "Drigg SB",
+			"code": "CUI",
 			"neighbours": [
 				{
 					"simId": "cumbriancoast",
@@ -208,6 +222,7 @@
 		{
 			"id": "sellafield",
 			"name": "Sellafield SB",
+			"code": "CUN",
 			"neighbours": [
 				{
 					"simId": "cumbriancoast",
@@ -222,6 +237,7 @@
 		{
 			"id": "stbees",
 			"name": "St Bees SB",
+			"code": "CUE",
 			"neighbours": [
 				{
 					"simId": "cumbriancoast",
@@ -236,6 +252,7 @@
 		{
 			"id": "bransty",
 			"name": "Bransty SB",
+			"code": "CUT",
 			"neighbours": [
 				{
 					"simId": "cumbriancoast",
@@ -250,6 +267,7 @@
 		{
 			"id": "workington2",
 			"name": "Workington No.2 SB",
+			"code": "CUW2",
 			"neighbours": [
 				{
 					"simId": "cumbriancoast",
@@ -264,6 +282,7 @@
 		{
 			"id": "workington3",
 			"name": "Workington No.3 SB",
+			"code": "CUW3",
 			"neighbours": [
 				{
 					"simId": "cumbriancoast",
@@ -278,6 +297,7 @@
 		{
 			"id": "maryport",
 			"name": "Maryport Station SB",
+			"code": "CUY",
 			"neighbours": [
 				{
 					"simId": "cumbriancoast",
@@ -292,6 +312,7 @@
 		{
 			"id": "wigton",
 			"name": "Wigton SB",
+			"code": "CUW",
 			"neighbours": [
 				{
 					"simId": "cumbriancoast",

--- a/server/simulations/derby.json
+++ b/server/simulations/derby.json
@@ -4,6 +4,7 @@
 		{
 			"id": "west",
 			"name": "West",
+			"code": "DBW",
 			"neighbours": [
 				{
 					"simId": "saltley",
@@ -34,6 +35,7 @@
 		{
 			"id": "centre",
 			"name": "Centre",
+			"code": "DBC",
 			"neighbours": [
 				{
 					"simId": "derby",
@@ -52,6 +54,7 @@
 		{
 			"id": "north",
 			"name": "North",
+			"code": "DBN",
 			"neighbours": [
 				{
 					"simId": "derby",
@@ -66,6 +69,7 @@
 		{
 			"id": "moirawest",
 			"name": "Moira West",
+			"code": "DBM",
 			"neighbours": [
 				{
 					"simId": "derby",
@@ -80,6 +84,7 @@
 		{
 			"id": "mantlelane",
 			"name": "Mantle Lane",
+			"code": "DBL",
 			"neighbours": [
 				{
 					"simId": "derby",

--- a/server/simulations/doncasternorth.json
+++ b/server/simulations/doncasternorth.json
@@ -4,6 +4,7 @@
 		{
 			"id": "panel4",
 			"name": "Panel 4",
+			"code": "DN4",
 			"neighbours": [
 				{
 					"simId": "doncasternorth",
@@ -30,6 +31,7 @@
 		{
 			"id": "panel5",
 			"name": "Panel 5",
+			"code": "DN5",
 			"neighbours": [
 				{
 					"simId": "southhumberside",

--- a/server/simulations/doncastersouth.json
+++ b/server/simulations/doncastersouth.json
@@ -4,6 +4,7 @@
 		{
 			"id": "panel2",
 			"name": "Panel 2",
+			"code": "DNC",
 			"neighbours": [
 				{
 					"simId": "doncastersouth",
@@ -14,6 +15,7 @@
 		{
 			"id": "panel1n",
 			"name": "Panel 1N",
+			"code": "DN1N",
 			"neighbours": [
 				{
 					"simId": "doncasterstation",
@@ -36,6 +38,7 @@
 		{
 			"id": "panel1s",
 			"name": "Panel 1S",
+			"code": "DN1S",
 			"neighbours": [
 				{
 					"simId": "doncastersouth",

--- a/server/simulations/doncasterstation.json
+++ b/server/simulations/doncasterstation.json
@@ -4,6 +4,7 @@
 		{
 			"id": "panel3",
 			"name": "Panel 3",
+			"code": "DN3",
 			"neighbours": [
 				{
 					"simId": "doncasternorth",
@@ -26,6 +27,7 @@
 		{
 			"id": "panel2",
 			"name": "Panel 2",
+			"code": "DN2",
 			"neighbours": [
 				{
 					"simId": "doncasterstation",

--- a/server/simulations/durhamcoast.json
+++ b/server/simulations/durhamcoast.json
@@ -4,6 +4,7 @@
 		{
 			"id": "lowgates",
 			"name": "Low Gates SB",
+			"code": "DCL",
 			"neighbours": [
 				{
 					"simId": "yorkns",
@@ -18,6 +19,7 @@
 		{
 			"id": "bowesfield",
 			"name": "Bowesfield SB",
+			"code": "DCB",
 			"neighbours": [
 				{
 					"simId": "tyneside",
@@ -32,6 +34,7 @@
 		{
 			"id": "ferryhill",
 			"name": "Ferryhill SB",
+			"code": "DCF",
 			"neighbours": [
 				{
 					"simId": "tyneside",
@@ -42,6 +45,7 @@
 		{
 			"id": "ryhopegrangejn",
 			"name": "Ryhope Grange Jn SB",
+			"code": "DCR",
 			"neighbours": [
 				{
 					"simId": "tyneside",

--- a/server/simulations/eastcoastway.json
+++ b/server/simulations/eastcoastway.json
@@ -4,6 +4,7 @@
 		{
 			"id": "lewes",
 			"name": "Lewes",
+			"code": "ECL",
 			"neighbours": [
 				{
 					"simId": "eastcoastway",
@@ -26,6 +27,7 @@
 		{
 			"id": "newhaventown",
 			"name": "Newhaven Town",
+			"code": "ECNT",
 			"neighbours": [
 				{
 					"simId": "eastcoastway",
@@ -40,6 +42,7 @@
 		{
 			"id": "newhavenharbour",
 			"name": "Newhaven Harbour",
+			"code": "ECNH",
 			"neighbours": [
 				{
 					"simId": "eastcoastway",
@@ -50,6 +53,7 @@
 		{
 			"id": "berwick",
 			"name": "Berwick",
+			"code": "ECB",
 			"neighbours": [
 				{
 					"simId": "eastcoastway",
@@ -64,6 +68,7 @@
 		{
 			"id": "polegate",
 			"name": "Polegate",
+			"code": "ECP",
 			"neighbours": [
 				{
 					"simId": "eastcoastway",
@@ -78,6 +83,7 @@
 		{
 			"id": "hampdenpark",
 			"name": "Hampden Park",
+			"code": "ECH",
 			"neighbours": [
 				{
 					"simId": "eastcoastway",
@@ -96,6 +102,7 @@
 		{
 			"id": "eastbourne",
 			"name": "Eastbourne",
+			"code": "ECE",
 			"neighbours": [
 				{
 					"simId": "eastcoastway",
@@ -106,6 +113,7 @@
 		{
 			"id": "pevenseywestham",
 			"name": "Pevensey & Westham",
+			"code": "ECW",
 			"neighbours": [
 				{
 					"simId": "eastcoastway",
@@ -120,6 +128,7 @@
 		{
 			"id": "bexhill",
 			"name": "Bexhill",
+			"code": "ECX",
 			"neighbours": [
 				{
 					"simId": "eastcoastway",

--- a/server/simulations/eastkent.json
+++ b/server/simulations/eastkent.json
@@ -4,6 +4,7 @@
 		{
 			"id": "rochester",
 			"name": "Rochester SB",
+			"code": "EKR",
 			"neighbours": [
 				{
 					"simId": "northkent",
@@ -18,6 +19,7 @@
 		{
 			"id": "cuxton",
 			"name": "Cuxton SB",
+			"code": "EKC",
 			"neighbours": [
 				{
 					"simId": "northkent",
@@ -28,6 +30,7 @@
 		{
 			"id": "wateringbury",
 			"name": "Wateringbury SB",
+			"code": "EKW",
 			"neighbours": [
 				{
 					"simId": "ashford",

--- a/server/simulations/eastleigh.json
+++ b/server/simulations/eastleigh.json
@@ -11,6 +11,24 @@
 				},
 				{
 					"simId": "eastleigh",
+					"panelId": "panel2"
+				},
+				{
+					"simId": "eastleigh",
+					"panelId": "panel3"
+				}
+			]
+		},
+		{
+			"id": "panel2",
+			"name": "Panel 2",
+			"neighbours": [
+				{
+					"simId": "eastleigh",
+					"panelId": "panel1"
+				},
+				{
+					"simId": "eastleigh",
 					"panelId": "panel3"
 				}
 			]
@@ -22,6 +40,10 @@
 				{
 					"simId": "eastleigh",
 					"panelId": "panel1"
+				},
+				{
+					"simId": "eastleigh",
+					"panelId": "panel2"
 				},
 				{
 					"simId": "salisbury",

--- a/server/simulations/eastleigh.json
+++ b/server/simulations/eastleigh.json
@@ -4,6 +4,7 @@
 		{
 			"id": "panel1",
 			"name": "Panel 1",
+			"code": "EH1",
 			"neighbours": [
 				{
 					"simId": "basingstoke",
@@ -22,6 +23,7 @@
 		{
 			"id": "panel2",
 			"name": "Panel 2",
+			"code": "EH2",
 			"neighbours": [
 				{
 					"simId": "eastleigh",
@@ -36,6 +38,7 @@
 		{
 			"id": "panel3",
 			"name": "Panel 3",
+			"code": "EH3",
 			"neighbours": [
 				{
 					"simId": "eastleigh",

--- a/server/simulations/eastleigh.json
+++ b/server/simulations/eastleigh.json
@@ -32,6 +32,10 @@
 				{
 					"simId": "eastleigh",
 					"panelId": "panel3"
+				},
+				{
+					"simId": "havant",
+					"panelId": "portsmouth"
 				}
 			]
 		},

--- a/server/simulations/eastwestrail.json
+++ b/server/simulations/eastwestrail.json
@@ -4,6 +4,7 @@
 		{
 			"id": "claydonjn",
 			"name": "Claydon L&NE Jn SB",
+			"code": "EWC",
 			"neighbours": [
 				{
 					"simId": "marylebone",
@@ -18,6 +19,7 @@
 		{
 			"id": "marstonvalewest",
 			"name": "Marston Vale West Workstation",
+			"code": "EWW",
 			"neighbours": [
 				{
 					"simId": "eastwestrail",
@@ -36,6 +38,7 @@
 		{
 			"id": "marstonvaleeast",
 			"name": "Marston Vale East Workstation",
+			"code": "EWE",
 			"neighbours": [
 				{
 					"simId": "eastwestrail",

--- a/server/simulations/edgehill.json
+++ b/server/simulations/edgehill.json
@@ -4,6 +4,7 @@
 		{
 			"id": "haltonjn",
 			"name": "Halton Jn",
+			"code": "EDH",
 			"neighbours": [
 				{
 					"simId": "crewe",
@@ -22,6 +23,7 @@
 		{
 			"id": "runcorn",
 			"name": "Runcorn",
+			"code": "EDR",
 			"neighbours": [
 				{
 					"simId": "edgehill",
@@ -36,6 +38,7 @@
 		{
 			"id": "monkssidings",
 			"name": "Monks Sidings",
+			"code": "EDM",
 			"neighbours": [
 				{
 					"simId": "edgehill",
@@ -50,6 +53,7 @@
 		{
 			"id": "fiddlersferry",
 			"name": "Fiddlers Ferry",
+			"code": "EDF",
 			"neighbours": [
 				{
 					"simId": "edgehill",
@@ -64,6 +68,7 @@
 		{
 			"id": "ditton",
 			"name": "Ditton",
+			"code": "EDD",
 			"neighbours": [
 				{
 					"simId": "edgehill",
@@ -82,6 +87,7 @@
 		{
 			"id": "spekejn",
 			"name": "Speke Jn",
+			"code": "EDS",
 			"neighbours": [
 				{
 					"simId": "edgehill",
@@ -96,6 +102,7 @@
 		{
 			"id": "allerton",
 			"name": "Allerton",
+			"code": "EDA",
 			"neighbours": [
 				{
 					"simId": "edgehill",
@@ -114,6 +121,7 @@
 		{
 			"id": "edgehill",
 			"name": "Edge Hill",
+			"code": "EDE",
 			"neighbours": [
 				{
 					"simId": "edgehill",
@@ -136,6 +144,7 @@
 		{
 			"id": "limestreet",
 			"name": "Lime Street",
+			"code": "EDL",
 			"neighbours": [
 				{
 					"simId": "edgehill",

--- a/server/simulations/edinburgh.json
+++ b/server/simulations/edinburgh.json
@@ -4,6 +4,7 @@
 		{
 			"id": "panel1",
 			"name": "Panel 1",
+			"code": "EB1",
 			"neighbours": [
 				{
 					"simId": "morpeth",
@@ -26,6 +27,7 @@
 		{
 			"id": "panel2",
 			"name": "Panel 2",
+			"code": "EB2",
 			"neighbours": [
 				{
 					"simId": "edinburgh",
@@ -48,6 +50,7 @@
 		{
 			"id": "panel3",
 			"name": "Panel 3",
+			"code": "EB3",
 			"neighbours": [
 				{
 					"simId": "edinburgh",
@@ -70,6 +73,7 @@
 		{
 			"id": "panel4",
 			"name": "Panel 4",
+			"code": "EB4",
 			"neighbours": [
 				{
 					"simId": "edinburgh",
@@ -100,6 +104,7 @@
 		{
 			"id": "panel5",
 			"name": "Panel 5",
+			"code": "EB5",
 			"neighbours": [
 				{
 					"simId": "edinburgh",
@@ -126,6 +131,7 @@
 		{
 			"id": "panel6",
 			"name": "Panel 6",
+			"code": "EB6",
 			"neighbours": [
 				{
 					"simId": "edinburgh",
@@ -144,6 +150,7 @@
 		{
 			"id": "millerhill",
 			"name": "Millerhill",
+			"code": "EBM",
 			"neighbours": [
 				{
 					"simId": "edinburgh",

--- a/server/simulations/ell.json
+++ b/server/simulations/ell.json
@@ -4,6 +4,7 @@
 		{
 			"id": "wks1",
 			"name": "Workstation 1",
+			"code": "EL1",
 			"neighbours": [
 				{
 					"simId": "ell",
@@ -14,6 +15,7 @@
 		{
 			"id": "wks2",
 			"name": "Workstation 2",
+			"code": "EL2",
 			"neighbours": [
 				{
 					"simId": "ell",

--- a/server/simulations/exeter.json
+++ b/server/simulations/exeter.json
@@ -4,6 +4,7 @@
 		{
 			"id": "panela",
 			"name": "Panel A",
+			"code": "EXA",
 			"neighbours": [
 				{
 					"simId": "plymouth",
@@ -22,6 +23,7 @@
 		{
 			"id": "paignton",
 			"name": "Paignton",
+			"code": "EXP",
 			"neighbours": [
 				{
 					"simId": "exeter",
@@ -32,6 +34,7 @@
 		{
 			"id": "panelb",
 			"name": "Panel B",
+			"code": "EXB",
 			"neighbours": [
 				{
 					"simId": "exeter",
@@ -54,6 +57,7 @@
 		{
 			"id": "exmouthjn",
 			"name": "Exmouth Jn",
+			"code": "EXE",
 			"neighbours": [
 				{
 					"simId": "exeter",
@@ -68,6 +72,7 @@
 		{
 			"id": "panelc",
 			"name": "Panel C",
+			"code": "EXC",
 			"neighbours": [
 				{
 					"simId": "exeter",
@@ -86,6 +91,7 @@
 		{
 			"id": "crediton",
 			"name": "Crediton",
+			"code": "EXR",
 			"neighbours": [
 				{
 					"simId": "exeter",

--- a/server/simulations/feltham.json
+++ b/server/simulations/feltham.json
@@ -4,6 +4,7 @@
 		{
 			"id": "reading",
 			"name": "Reading",
+			"code": "FHR",
 			"neighbours": [
 				{
 					"simId": "feltham",
@@ -14,6 +15,7 @@
 		{
 			"id": "wokingham",
 			"name": "Wokingham",
+			"code": "FHW",
 			"neighbours": [
 				{
 					"simId": "feltham",
@@ -32,6 +34,7 @@
 		{
 			"id": "ascot",
 			"name": "Ascot",
+			"code": "FHA",
 			"neighbours": [
 				{
 					"simId": "feltham",
@@ -54,6 +57,7 @@
 		{
 			"id": "staines",
 			"name": "Staines",
+			"code": "FHS",
 			"neighbours": [
 				{
 					"simId": "feltham",
@@ -68,6 +72,7 @@
 		{
 			"id": "hounslow",
 			"name": "Hounslow",
+			"code": "FHH",
 			"neighbours": [
 				{
 					"simId": "feltham",
@@ -90,6 +95,7 @@
 		{
 			"id": "twickenham",
 			"name": "Twickenham",
+			"code": "FHT",
 			"neighbours": [
 				{
 					"simId": "feltham",
@@ -108,6 +114,7 @@
 		{
 			"id": "strawberryhill",
 			"name": "Strawberry Hill",
+			"code": "FHR",
 			"neighbours": [
 				{
 					"simId": "feltham",
@@ -122,6 +129,7 @@
 		{
 			"id": "barnes",
 			"name": "Barnes",
+			"code": "FHB",
 			"neighbours": [
 				{
 					"simId": "feltham",

--- a/server/simulations/feltham.json
+++ b/server/simulations/feltham.json
@@ -114,7 +114,7 @@
 		{
 			"id": "strawberryhill",
 			"name": "Strawberry Hill",
-			"code": "FHR",
+			"code": "FHL",
 			"neighbours": [
 				{
 					"simId": "feltham",

--- a/server/simulations/feltham.json
+++ b/server/simulations/feltham.json
@@ -27,7 +27,7 @@
 				},
 				{
 					"simId": "guildford",
-					"panelId": "east"
+					"panelId": "guildford"
 				}
 			]
 		},

--- a/server/simulations/gemlsouth.json
+++ b/server/simulations/gemlsouth.json
@@ -4,6 +4,7 @@
 		{
 			"id": "stratford",
 			"name": "Stratford Workstation",
+			"code": "GES",
 			"neighbours": [
 				{
 					"simId": "livst",
@@ -30,6 +31,7 @@
 		{
 			"id": "ilford",
 			"name": "Ilford Workstation",
+			"code": "GEI",
 			"neighbours": [
 				{
 					"simId": "gemlsouth",

--- a/server/simulations/glasgow.json
+++ b/server/simulations/glasgow.json
@@ -4,6 +4,7 @@
 		{
 			"id": "station",
 			"name": "Station",
+			"code": "GGS",
 			"neighbours": [
 				{
 					"simId": "glasgow",
@@ -14,6 +15,7 @@
 		{
 			"id": "bridgestreet",
 			"name": "Bridge Street",
+			"code": "GGB",
 			"neighbours": [
 				{
 					"simId": "glasgow",
@@ -36,6 +38,7 @@
 		{
 			"id": "polmadie",
 			"name": "Polmadie",
+			"code": "GGP",
 			"neighbours": [
 				{
 					"simId": "glasgow",
@@ -66,6 +69,7 @@
 		{
 			"id": "muirhouse",
 			"name": "Muirhouse",
+			"code": "GGM",
 			"neighbours": [
 				{
 					"simId": "glasgow",
@@ -88,6 +92,7 @@
 		{
 			"id": "shields",
 			"name": "Shields",
+			"code": "GGS",
 			"neighbours": [
 				{
 					"simId": "glasgow",

--- a/server/simulations/glasgow.json
+++ b/server/simulations/glasgow.json
@@ -92,7 +92,7 @@
 		{
 			"id": "shields",
 			"name": "Shields",
-			"code": "GGS",
+			"code": "GGH",
 			"neighbours": [
 				{
 					"simId": "glasgow",

--- a/server/simulations/gloucester.json
+++ b/server/simulations/gloucester.json
@@ -4,6 +4,7 @@
 		{
 			"id": "north",
 			"name": "North Panel",
+			"code": "GLN",
 			"neighbours": [
 				{
 					"simId": "saltley",
@@ -26,6 +27,7 @@
 		{
 			"id": "central",
 			"name": "Central Panel",
+			"code": "GLC",
 			"neighbours": [
 				{
 					"simId": "gloucester",
@@ -40,6 +42,7 @@
 		{
 			"id": "south",
 			"name": "South Panel",
+			"code": "GLS",
 			"neighbours": [
 				{
 					"simId": "gloucester",

--- a/server/simulations/gsw.json
+++ b/server/simulations/gsw.json
@@ -4,6 +4,7 @@
 		{
 			"id": "barrhead",
 			"name": "Barrhead SB",
+			"code": "GSB",
 			"neighbours": [
 				{
 					"simId": "glasgow",
@@ -18,6 +19,7 @@
 		{
 			"id": "lugton",
 			"name": "Lugton SB",
+			"code": "GSL",
 			"neighbours": [
 				{
 					"simId": "gsw",
@@ -32,6 +34,7 @@
 		{
 			"id": "kilmarnock",
 			"name": "Kilmarnock SB",
+			"code": "GSK",
 			"neighbours": [
 				{
 					"simId": "gsw",
@@ -50,6 +53,7 @@
 		{
 			"id": "hurlford",
 			"name": "Hurlford SB",
+			"code": "GSH",
 			"neighbours": [
 				{
 					"simId": "gsw",
@@ -64,6 +68,7 @@
 		{
 			"id": "mauchline",
 			"name": "Mauchline SB",
+			"code": "GSM",
 			"neighbours": [
 				{
 					"simId": "gsw",
@@ -82,6 +87,7 @@
 		{
 			"id": "newcumnock",
 			"name": "New Cumnock SB",
+			"code": "GSN",
 			"neighbours": [
 				{
 					"simId": "gsw",
@@ -96,6 +102,7 @@
 		{
 			"id": "kirkconnel",
 			"name": "Kirkconnel SB",
+			"code": "GSC",
 			"neighbours": [
 				{
 					"simId": "gsw",
@@ -110,6 +117,7 @@
 		{
 			"id": "thornhill",
 			"name": "Thornhill SB",
+			"code": "GST",
 			"neighbours": [
 				{
 					"simId": "gsw",
@@ -124,6 +132,7 @@
 		{
 			"id": "holywood",
 			"name": "Holywood SB",
+			"code": "GSH",
 			"neighbours": [
 				{
 					"simId": "gsw",
@@ -138,6 +147,7 @@
 		{
 			"id": "dumfries",
 			"name": "Dumfries Station SB",
+			"code": "GSD",
 			"neighbours": [
 				{
 					"simId": "gsw",
@@ -156,6 +166,7 @@
 		{
 			"id": "annan",
 			"name": "Annan SB",
+			"code": "GSA",
 			"neighbours": [
 				{
 					"simId": "gsw",

--- a/server/simulations/gsw.json
+++ b/server/simulations/gsw.json
@@ -132,7 +132,7 @@
 		{
 			"id": "holywood",
 			"name": "Holywood SB",
-			"code": "GSH",
+			"code": "GSY",
 			"neighbours": [
 				{
 					"simId": "gsw",

--- a/server/simulations/guildford.json
+++ b/server/simulations/guildford.json
@@ -4,6 +4,7 @@
 		{
 			"id": "east",
 			"name": "East",
+			"code": "GFE",
 			"neighbours": [
 				{
 					"simId": "guildford",
@@ -34,6 +35,7 @@
 		{
 			"id": "west",
 			"name": "West",
+			"code": "GFW",
 			"neighbours": [
 				{
 					"simId": "guildford",

--- a/server/simulations/guildford.json
+++ b/server/simulations/guildford.json
@@ -1,15 +1,11 @@
 {
-	"name": "Guildford PSB",
+	"name": "Guildford",
 	"panels": [
 		{
-			"id": "east",
-			"name": "East",
-			"code": "GFE",
+			"id": "guildford",
+			"name": "Guildford",
+			"code": "GDD",
 			"neighbours": [
-				{
-					"simId": "guildford",
-					"panelId": "west"
-				},
 				{
 					"simId": "woking",
 					"panelId": "aldershot"
@@ -29,21 +25,55 @@
 				{
 					"simId": "wimbledon",
 					"panelId": "panel4"
-				}
-			]
-		},
-		{
-			"id": "west",
-			"name": "West",
-			"code": "GFW",
-			"neighbours": [
-				{
-					"simId": "guildford",
-					"panelId": "east"
 				},
 				{
 					"simId": "threebridges",
 					"panelId": "reigate"
+				}
+			]
+		},
+		{
+			"id": "farncombe",
+			"name": "Farncombe",
+			"code": "GDF",
+			"neighbours": [
+				{
+					"simId": "guildford",
+					"panelId": "guildford"
+				},
+				{
+					"simId": "guildford",
+					"panelId": "haslemere"
+				}
+			]
+		},
+		{
+			"id": "haslemere",
+			"name": "Haslemere",
+			"code": "GDH",
+			"neighbours": [
+				{
+					"simId": "guildford",
+					"panelId": "farncombe"
+				},
+				{
+					"simId": "guildford",
+					"panelId": "petersfield"
+				}
+			]
+		},
+		{
+			"id": "petersfield",
+			"name": "Petersfield",
+			"code": "GDP",
+			"neighbours": [
+				{
+					"simId": "guildford",
+					"panelId": "haslemere"
+				},
+				{
+					"simId": "havant",
+					"panelId": "portsmouth"
 				}
 			]
 		}

--- a/server/simulations/harrogate.json
+++ b/server/simulations/harrogate.json
@@ -4,6 +4,7 @@
 		{
 			"id": "horsforth",
 			"name": "Horsforth SB",
+			"code": "HGF",
 			"neighbours": [
 				{
 					"simId": "leedsew",
@@ -18,6 +19,7 @@
 		{
 			"id": "rigton",
 			"name": "Rigton SB",
+			"code": "HGR",
 			"neighbours": [
 				{
 					"simId": "harrogate",
@@ -32,6 +34,7 @@
 		{
 			"id": "harrogate",
 			"name": "Harrogate SB",
+			"code": "HGH",
 			"neighbours": [
 				{
 					"simId": "harrogate",
@@ -46,6 +49,7 @@
 		{
 			"id": "starbeck",
 			"name": "Starbeck SB",
+			"code": "HGS",
 			"neighbours": [
 				{
 					"simId": "harrogate",
@@ -60,6 +64,7 @@
 		{
 			"id": "knaresborough",
 			"name": "Knaresborough SB",
+			"code": "HGK",
 			"neighbours": [
 				{
 					"simId": "harrogate",
@@ -74,6 +79,7 @@
 		{
 			"id": "cattal",
 			"name": "Cattal SB",
+			"code": "HGC",
 			"neighbours": [
 				{
 					"simId": "harrogate",
@@ -88,6 +94,7 @@
 		{
 			"id": "hammerton",
 			"name": "Hammerton SB",
+			"code": "HGM",
 			"neighbours": [
 				{
 					"simId": "harrogate",
@@ -102,6 +109,7 @@
 		{
 			"id": "poppleton",
 			"name": "Poppleton SB",
+			"code": "HGP",
 			"neighbours": [
 				{
 					"simId": "harrogate",

--- a/server/simulations/hastings.json
+++ b/server/simulations/hastings.json
@@ -4,6 +4,7 @@
 		{
 			"id": "robertsbridge",
 			"name": "Robertsbridge SB",
+			"code": "HSR",
 			"neighbours": [
 				{
 					"simId": "ashford",
@@ -18,6 +19,7 @@
 		{
 			"id": "bopeepjn",
 			"name": "Bo Peep Jn SB",
+			"code": "HSB",
 			"neighbours": [
 				{
 					"simId": "hastings",
@@ -36,6 +38,7 @@
 		{
 			"id": "hastings",
 			"name": "Hastings SB",
+			"code": "HSH",
 			"neighbours": [
 				{
 					"simId": "hastings",
@@ -50,6 +53,7 @@
 		{
 			"id": "rye",
 			"name": "Rye SB",
+			"code": "HSY",
 			"neighbours": [
 				{
 					"simId": "hastings",

--- a/server/simulations/havant.json
+++ b/server/simulations/havant.json
@@ -1,0 +1,20 @@
+{
+	"name": "Havant",
+	"panels": [
+		{
+			"id": "portsmouth",
+			"name": "Portsmouth",
+			"code": "HTP",
+			"neighbours": [
+				{
+					"simId": "eastleigh",
+					"panelId": "panel2"
+				},
+				{
+					"simId": "guildford",
+					"panelId": "petersfield"
+				}
+			]
+		}
+	]
+}

--- a/server/simulations/hereford.json
+++ b/server/simulations/hereford.json
@@ -4,6 +4,7 @@
 		{
 			"id": "dorrington",
 			"name": "Dorrington",
+			"code": "HFD",
 			"neighbours": [
 				{
 					"simId": "shrewsbury",
@@ -18,6 +19,7 @@
 		{
 			"id": "marshbrook",
 			"name": "Marsh Brook",
+			"code": "HFM",
 			"neighbours": [
 				{
 					"simId": "hereford",
@@ -32,6 +34,7 @@
 		{
 			"id": "cravenarms",
 			"name": "Craven Arms",
+			"code": "HFC",
 			"neighbours": [
 				{
 					"simId": "hereford",
@@ -50,6 +53,7 @@
 		{
 			"id": "onibury",
 			"name": "Onibury",
+			"code": "HFO",
 			"neighbours": [
 				{
 					"simId": "hereford",
@@ -64,6 +68,7 @@
 		{
 			"id": "bromfield",
 			"name": "Bromfield",
+			"code": "HFB",
 			"neighbours": [
 				{
 					"simId": "hereford",
@@ -78,6 +83,7 @@
 		{
 			"id": "woofferton",
 			"name": "Woofferton",
+			"code": "HFW",
 			"neighbours": [
 				{
 					"simId": "hereford",
@@ -92,6 +98,7 @@
 		{
 			"id": "leominster",
 			"name": "Leominster",
+			"code": "HFE",
 			"neighbours": [
 				{
 					"simId": "hereford",
@@ -106,6 +113,7 @@
 		{
 			"id": "moretononlugg",
 			"name": "Moreton on Lugg",
+			"code": "HFG",
 			"neighbours": [
 				{
 					"simId": "hereford",
@@ -120,6 +128,7 @@
 		{
 			"id": "hereford",
 			"name": "Hereford",
+			"code": "HFH",
 			"neighbours": [
 				{
 					"simId": "hereford",
@@ -138,6 +147,7 @@
 		{
 			"id": "traminn",
 			"name": "Tram Inn",
+			"code": "HFT",
 			"neighbours": [
 				{
 					"simId": "hereford",
@@ -152,6 +162,7 @@
 		{
 			"id": "pontrilias",
 			"name": "Pontrilias",
+			"code": "HFI",
 			"neighbours": [
 				{
 					"simId": "hereford",
@@ -166,6 +177,7 @@
 		{
 			"id": "abergavenny",
 			"name": "Abergavenny",
+			"code": "HFA",
 			"neighbours": [
 				{
 					"simId": "hereford",
@@ -180,6 +192,7 @@
 		{
 			"id": "littlemilljn",
 			"name": "Little Mill Junction",
+			"code": "HFL",
 			"neighbours": [
 				{
 					"simId": "hereford",
@@ -194,6 +207,7 @@
 		{
 			"id": "pantyffynnon",
 			"name": "Pantyffynnon",
+			"code": "HFP",
 			"neighbours": [
 				{
 					"simId": "hereford",

--- a/server/simulations/hopevalley.json
+++ b/server/simulations/hopevalley.json
@@ -4,6 +4,7 @@
 		{
 			"id": "hazelgrove",
 			"name": "Hazel Grove SB",
+			"code": "HVH",
 			"neighbours": [
 				{
 					"simId": "stockport",
@@ -26,6 +27,7 @@
 		{
 			"id": "newmillscentral",
 			"name": "New Mills Central SB",
+			"code": "HVNC",
 			"neighbours": [
 				{
 					"simId": "manchestereast",
@@ -40,6 +42,7 @@
 		{
 			"id": "newmillssouthjn",
 			"name": "New Mills South Jn SB",
+			"code": "HVNS",
 			"neighbours": [
 				{
 					"simId": "hopevalley",
@@ -58,6 +61,7 @@
 		{
 			"id": "chinley",
 			"name": "Chinley SB",
+			"code": "HVC",
 			"neighbours": [
 				{
 					"simId": "hopevalley",
@@ -76,6 +80,7 @@
 		{
 			"id": "edale",
 			"name": "Edale SB",
+			"code": "HVE",
 			"neighbours": [
 				{
 					"simId": "hopevalley",
@@ -90,6 +95,7 @@
 		{
 			"id": "earlessidings",
 			"name": "Earles Sidings SB",
+			"code": "HVA",
 			"neighbours": [
 				{
 					"simId": "hopevalley",
@@ -104,6 +110,7 @@
 		{
 			"id": "grindleford",
 			"name": "Grindleford SB",
+			"code": "HVG",
 			"neighbours": [
 				{
 					"simId": "hopevalley",
@@ -118,6 +125,7 @@
 		{
 			"id": "totleytunneleast",
 			"name": "Totley Tunnel East SB",
+			"code": "HVT",
 			"neighbours": [
 				{
 					"simId": "hopevalley",
@@ -132,6 +140,7 @@
 		{
 			"id": "peakforestsouth",
 			"name": "Peak Forest South SB",
+			"code": "HVP",
 			"neighbours": [
 				{
 					"simId": "hopevalley",
@@ -146,6 +155,7 @@
 		{
 			"id": "greatrocksjn",
 			"name": "Great Rocks Junction SB",
+			"code": "HVG",
 			"neighbours": [
 				{
 					"simId": "hopevalley",
@@ -160,6 +170,7 @@
 		{
 			"id": "furnessvale",
 			"name": "Furness Vale SB",
+			"code": "HVF",
 			"neighbours": [
 				{
 					"simId": "hopevalley",
@@ -174,6 +185,7 @@
 		{
 			"id": "chapelenlefrith",
 			"name": "Chapel-en-le-Frith SB",
+			"code": "HVL",
 			"neighbours": [
 				{
 					"simId": "hopevalley",
@@ -188,6 +200,7 @@
 		{
 			"id": "buxton",
 			"name": "Buxton SB",
+			"code": "HVB",
 			"neighbours": [
 				{
 					"simId": "hopevalley",

--- a/server/simulations/hopevalley.json
+++ b/server/simulations/hopevalley.json
@@ -155,7 +155,7 @@
 		{
 			"id": "greatrocksjn",
 			"name": "Great Rocks Junction SB",
-			"code": "HVG",
+			"code": "HVR",
 			"neighbours": [
 				{
 					"simId": "hopevalley",

--- a/server/simulations/horsham.json
+++ b/server/simulations/horsham.json
@@ -4,6 +4,7 @@
 		{
 			"id": "horsham",
 			"name": "Horsham",
+			"code": "HOH",
 			"neighbours": [
 				{
 					"simId": "horsham",
@@ -22,6 +23,7 @@
 		{
 			"id": "dorking",
 			"name": "Dorking",
+			"code": "HOD",
 			"neighbours": [
 				{
 					"simId": "wimbledon",

--- a/server/simulations/huddersfield.json
+++ b/server/simulations/huddersfield.json
@@ -4,6 +4,7 @@
 		{
 			"id": "huddersfield",
 			"name": "Huddersfield",
+			"code": "HUH",
 			"neighbours": [
 				{
 					"simId": "huddersfield",
@@ -22,6 +23,7 @@
 		{
 			"id": "digglejn",
 			"name": "Diggle Jn",
+			"code": "HUD",
 			"neighbours": [
 				{
 					"simId": "huddersfield",

--- a/server/simulations/hull.json
+++ b/server/simulations/hull.json
@@ -4,6 +4,7 @@
 		{
 			"id": "goole",
 			"name": "Goole SB",
+			"code": "HLG",
 			"neighbours": [
 				{
 					"simId": "doncasternorth",
@@ -22,6 +23,7 @@
 		{
 			"id": "goolebridge",
 			"name": "Goole Bridge SB",
+			"code": "HLB",
 			"neighbours": [
 				{
 					"simId": "hull",
@@ -36,6 +38,7 @@
 		{
 			"id": "selby",
 			"name": "Selby SB",
+			"code": "HLS",
 			"neighbours": [
 				{
 					"simId": "yorkns",
@@ -50,6 +53,7 @@
 		{
 			"id": "brough",
 			"name": "Brough Workstation",
+			"code": "HLB",
 			"neighbours": [
 				{
 					"simId": "hull",
@@ -68,6 +72,7 @@
 		{
 			"id": "hessleroad",
 			"name": "Hessle Road SB",
+			"code": "HLH",
 			"neighbours": [
 				{
 					"simId": "hull",
@@ -82,6 +87,7 @@
 		{
 			"id": "hullparagon",
 			"name": "Hull Paragon SB",
+			"code": "HLP",
 			"neighbours": [
 				{
 					"simId": "hull",

--- a/server/simulations/hull.json
+++ b/server/simulations/hull.json
@@ -53,7 +53,7 @@
 		{
 			"id": "brough",
 			"name": "Brough Workstation",
-			"code": "HLB",
+			"code": "HLR",
 			"neighbours": [
 				{
 					"simId": "hull",

--- a/server/simulations/huntscross.json
+++ b/server/simulations/huntscross.json
@@ -4,6 +4,7 @@
 		{
 			"id": "huntscross",
 			"name": "Hunts Cross",
+			"code": "HCH",
 			"neighbours": [
 				{
 					"simId": "sandhills",
@@ -22,6 +23,7 @@
 		{
 			"id": "warringtoncentral",
 			"name": "Warrington Central",
+			"code": "HCW",
 			"neighbours": [
 				{
 					"simId": "huntscross",
@@ -36,6 +38,7 @@
 		{
 			"id": "glazebrookeastjn",
 			"name": "Glazebrook East Jn",
+			"code": "HCG",
 			"neighbours": [
 				{
 					"simId": "huntscross",

--- a/server/simulations/huyton.json
+++ b/server/simulations/huyton.json
@@ -4,6 +4,7 @@
 		{
 			"id": "mroc",
 			"name": "MROC",
+			"code": "HYL",
 			"neighbours": [
 				{
 					"simId": "huyton",
@@ -22,6 +23,7 @@
 		{
 			"id": "sthelens",
 			"name": "St Helens",
+			"code": "HYH",
 			"neighbours": [
 				{
 					"simId": "huyton",

--- a/server/simulations/inverness.json
+++ b/server/simulations/inverness.json
@@ -4,6 +4,7 @@
 		{
 			"id": "dunkeld",
 			"name": "Dunkeld SB",
+			"code": "IVK",
 			"neighbours": [
 				{
 					"simId": "nescot",
@@ -14,6 +15,7 @@
 		{
 			"id": "dyce",
 			"name": "Dyce SB",
+			"code": "IVY",
 			"neighbours": [
 				{
 					"simId": "nescot",

--- a/server/simulations/kingsx.json
+++ b/server/simulations/kingsx.json
@@ -4,6 +4,7 @@
 		{
 			"id": "cross",
 			"name": "Cross",
+			"code": "KXX",
 			"neighbours": [
 				{
 					"simId": "kingsx",
@@ -22,6 +23,7 @@
 		{
 			"id": "finsbury",
 			"name": "Finsbury",
+			"code": "KXF",
 			"neighbours": [
 				{
 					"simId": "kingsx",
@@ -44,6 +46,7 @@
 		{
 			"id": "palace",
 			"name": "Palace",
+			"code": "KXP",
 			"neighbours": [
 				{
 					"simId": "kingsx",
@@ -62,6 +65,7 @@
 		{
 			"id": "welwyn",
 			"name": "Welwyn",
+			"code": "KXW",
 			"neighbours": [
 				{
 					"simId": "kingsx",
@@ -76,6 +80,7 @@
 		{
 			"id": "hitchin",
 			"name": "Hitchin",
+			"code": "KXH",
 			"neighbours": [
 				{
 					"simId": "kingsx",

--- a/server/simulations/lancing.json
+++ b/server/simulations/lancing.json
@@ -4,6 +4,7 @@
 		{
 			"id": "panel1",
 			"name": "Panel 1",
+			"code": "LC",
 			"neighbours": [
 				{
 					"simId": "threebridges",

--- a/server/simulations/leamington.json
+++ b/server/simulations/leamington.json
@@ -4,6 +4,7 @@
 		{
 			"id": "leamington",
 			"name": "Leamington",
+			"code": "LM",
 			"neighbours": [
 				{
 					"simId": "saltley",

--- a/server/simulations/leedsa.json
+++ b/server/simulations/leedsa.json
@@ -4,6 +4,7 @@
 		{
 			"id": "ardsley",
 			"name": "Ardsley",
+			"code": "LA",
 			"neighbours": [
 				{
 					"simId": "sheffield",

--- a/server/simulations/leedsew.json
+++ b/server/simulations/leedsew.json
@@ -4,6 +4,7 @@
 		{
 			"id": "west1",
 			"name": "West 1",
+			"code": "LSW1",
 			"neighbours": [
 				{
 					"simId": "leedsew",
@@ -38,6 +39,7 @@
 		{
 			"id": "west2",
 			"name": "West 2",
+			"code": "LSW2",
 			"neighbours": [
 				{
 					"simId": "leedsew",
@@ -52,6 +54,7 @@
 		{
 			"id": "east1",
 			"name": "East 1",
+			"code": "LSE1",
 			"neighbours": [
 				{
 					"simId": "leedsew",
@@ -66,6 +69,7 @@
 		{
 			"id": "east2",
 			"name": "East 2",
+			"code": "LSE2",
 			"neighbours": [
 				{
 					"simId": "leedsew",

--- a/server/simulations/leedsnw.json
+++ b/server/simulations/leedsnw.json
@@ -4,6 +4,7 @@
 		{
 			"id": "leedsnw",
 			"name": "Leeds Northwest",
+			"code": "LN",
 			"neighbours": [
 				{
 					"simId": "leedsew",

--- a/server/simulations/leicester.json
+++ b/server/simulations/leicester.json
@@ -4,6 +4,7 @@
 		{
 			"id": "south",
 			"name": "South panel",
+			"code": "LSS",
 			"neighbours": [
 				{
 					"simId": "westhampstead",
@@ -26,6 +27,7 @@
 		{
 			"id": "croft",
 			"name": "Croft SB",
+			"code": "LSC",
 			"neighbours": [
 				{
 					"simId": "leicester",
@@ -40,6 +42,7 @@
 		{
 			"id": "north",
 			"name": "North panel",
+			"code": "LSN",
 			"neighbours": [
 				{
 					"simId": "leicester",
@@ -62,6 +65,7 @@
 		{
 			"id": "bardonhill",
 			"name": "Bardon Hill SB",
+			"code": "LSB",
 			"neighbours": [
 				{
 					"simId": "leicester",
@@ -76,6 +80,7 @@
 		{
 			"id": "frisby",
 			"name": "Frisby SB",
+			"code": "LSF",
 			"neighbours": [
 				{
 					"simId": "leicester",
@@ -90,6 +95,7 @@
 		{
 			"id": "melton",
 			"name": "Melton Station SB",
+			"code": "LSM",
 			"neighbours": [
 				{
 					"simId": "leicester",
@@ -104,6 +110,7 @@
 		{
 			"id": "whissendine",
 			"name": "Whissendine SB",
+			"code": "LSW",
 			"neighbours": [
 				{
 					"simId": "leicester",
@@ -118,6 +125,7 @@
 		{
 			"id": "ashwell",
 			"name": "Ashwell SB",
+			"code": "LSA",
 			"neighbours": [
 				{
 					"simId": "leicester",
@@ -132,6 +140,7 @@
 		{
 			"id": "langhamjn",
 			"name": "Langham Junction SB",
+			"code": "LSL",
 			"neighbours": [
 				{
 					"simId": "leicester",
@@ -146,6 +155,7 @@
 		{
 			"id": "oakham",
 			"name": "Oakham Level Crossing SB",
+			"code": "LSO",
 			"neighbours": [
 				{
 					"simId": "leicester",
@@ -160,6 +170,7 @@
 		{
 			"id": "mantonjn",
 			"name": "Manton Junction SB",
+			"code": "LSM",
 			"neighbours": [
 				{
 					"simId": "leicester",
@@ -178,6 +189,7 @@
 		{
 			"id": "ketton",
 			"name": "Ketton SB",
+			"code": "LSK",
 			"neighbours": [
 				{
 					"simId": "leicester",
@@ -192,6 +204,7 @@
 		{
 			"id": "uffington",
 			"name": "Uffington & Barnack SB",
+			"code": "LSU",
 			"neighbours": [
 				{
 					"simId": "leicester",

--- a/server/simulations/leicester.json
+++ b/server/simulations/leicester.json
@@ -170,7 +170,7 @@
 		{
 			"id": "mantonjn",
 			"name": "Manton Junction SB",
-			"code": "LSM",
+			"code": "LST",
 			"neighbours": [
 				{
 					"simId": "leicester",

--- a/server/simulations/lincoln.json
+++ b/server/simulations/lincoln.json
@@ -140,7 +140,7 @@
 		{
 			"id": "allington",
 			"name": "Allington SB",
-			"code": "LCAC",
+			"code": "LCAL",
 			"neighbours": [
 				{
 					"simId": "trent",
@@ -159,7 +159,7 @@
 		{
 			"id": "ancaster",
 			"name": "Ancaster SB",
-			"code": "LCRA",
+			"code": "LCAC",
 			"neighbours": [
 				{
 					"simId": "lincoln",

--- a/server/simulations/lincoln.json
+++ b/server/simulations/lincoln.json
@@ -4,6 +4,7 @@
 		{
 			"id": "south",
 			"name": "South Workstation",
+			"code": "LCS",
 			"neighbours": [
 				{
 					"simId": "peterborough",
@@ -18,6 +19,7 @@
 		{
 			"id": "east",
 			"name": "East Workstation",
+			"code": "LCE",
 			"neighbours": [
 				{
 					"simId": "lincoln",
@@ -40,6 +42,7 @@
 		{
 			"id": "city",
 			"name": "City Workstation",
+			"code": "LCC",
 			"neighbours": [
 				{
 					"simId": "lincoln",
@@ -58,6 +61,7 @@
 		{
 			"id": "west",
 			"name": "West Workstation",
+			"code": "LCW",
 			"neighbours": [
 				{
 					"simId": "lincoln",
@@ -76,6 +80,7 @@
 		{
 			"id": "swinderby",
 			"name": "Swinderby SB",
+			"code": "LCSB",
 			"neighbours": [
 				{
 					"simId": "lincoln",
@@ -90,6 +95,7 @@
 		{
 			"id": "langworth",
 			"name": "Langworth SB",
+			"code": "LCLG",
 			"neighbours": [
 				{
 					"simId": "lincoln",
@@ -104,6 +110,7 @@
 		{
 			"id": "wickenby",
 			"name": "Wickenby SB",
+			"code": "LCWB",
 			"neighbours": [
 				{
 					"simId": "lincoln",
@@ -118,6 +125,7 @@
 		{
 			"id": "holtonlemoor",
 			"name": "Holton-le-Moor SB",
+			"code": "LCHM",
 			"neighbours": [
 				{
 					"simId": "lincoln",
@@ -132,6 +140,7 @@
 		{
 			"id": "allington",
 			"name": "Allington SB",
+			"code": "LCAC",
 			"neighbours": [
 				{
 					"simId": "trent",
@@ -150,6 +159,7 @@
 		{
 			"id": "ancaster",
 			"name": "Ancaster SB",
+			"code": "LCRA",
 			"neighbours": [
 				{
 					"simId": "lincoln",
@@ -164,6 +174,7 @@
 		{
 			"id": "rauceby",
 			"name": "Rauceby SB",
+			"code": "LCRA",
 			"neighbours": [
 				{
 					"simId": "lincoln",
@@ -178,6 +189,7 @@
 		{
 			"id": "sleafordwest",
 			"name": "Sleaford West SB",
+			"code": "LCSW",
 			"neighbours": [
 				{
 					"simId": "lincoln",
@@ -196,6 +208,7 @@
 		{
 			"id": "sleafordeast",
 			"name": "Sleaford East SB",
+			"code": "LCSE",
 			"neighbours": [
 				{
 					"simId": "lincoln",
@@ -214,6 +227,7 @@
 		{
 			"id": "heckington",
 			"name": "Heckington SB",
+			"code": "LCHE",
 			"neighbours": [
 				{
 					"simId": "lincoln",
@@ -228,6 +242,7 @@
 		{
 			"id": "hubbertsbridge",
 			"name": "Hubberts Bridge SB",
+			"code": "LCHB",
 			"neighbours": [
 				{
 					"simId": "lincoln",
@@ -242,6 +257,7 @@
 		{
 			"id": "weststreetjn",
 			"name": "Boston West Street Jn SB",
+			"code": "LCBW",
 			"neighbours": [
 				{
 					"simId": "lincoln",
@@ -256,6 +272,7 @@
 		{
 			"id": "sibsey",
 			"name": "Sibsey SB",
+			"code": "LCSY",
 			"neighbours": [
 				{
 					"simId": "lincoln",
@@ -270,6 +287,7 @@
 		{
 			"id": "bellwaterjn",
 			"name": "Bellwater Jn SB",
+			"code": "LCBJ",
 			"neighbours": [
 				{
 					"simId": "lincoln",
@@ -284,6 +302,7 @@
 		{
 			"id": "thorpeculvert",
 			"name": "Thorpe Culvert SB",
+			"code": "LCTC",
 			"neighbours": [
 				{
 					"simId": "lincoln",
@@ -298,6 +317,7 @@
 		{
 			"id": "wainfleet",
 			"name": "Wainfleet SB",
+			"code": "LCWA",
 			"neighbours": [
 				{
 					"simId": "lincoln",
@@ -312,6 +332,7 @@
 		{
 			"id": "skegness",
 			"name": "Skegness SB",
+			"code": "LCSK",
 			"neighbours": [
 				{
 					"simId": "lincoln",

--- a/server/simulations/livst.json
+++ b/server/simulations/livst.json
@@ -4,6 +4,7 @@
 		{
 			"id": "wa",
 			"name": "West Anglia",
+			"code": "LVA",
 			"neighbours": [
 				{
 					"simId": "livst",
@@ -18,6 +19,7 @@
 		{
 			"id": "ge",
 			"name": "Great Eastern",
+			"code": "LVE",
 			"neighbours": [
 				{
 					"simId": "livst",

--- a/server/simulations/londonbridgeasc.json
+++ b/server/simulations/londonbridgeasc.json
@@ -4,6 +4,7 @@
 		{
 			"id": "panel1",
 			"name": "Panel 1",
+			"code": "LB1",
 			"neighbours": [
 				{
 					"simId": "londonbridgeasc",
@@ -18,6 +19,7 @@
 		{
 			"id": "panel2",
 			"name": "Panel 2",
+			"code": "LB2",
 			"neighbours": [
 				{
 					"simId": "londonbridgeasc",
@@ -36,6 +38,7 @@
 		{
 			"id": "panel3",
 			"name": "Panel 3",
+			"code": "LB3",
 			"neighbours": [
 				{
 					"simId": "londonbridgeasc",
@@ -58,6 +61,7 @@
 		{
 			"id": "panel4",
 			"name": "Panel 4",
+			"code": "LB4",
 			"neighbours": [
 				{
 					"simId": "londonbridgeasc",
@@ -72,6 +76,7 @@
 		{
 			"id": "panel5",
 			"name": "Panel 5",
+			"code": "LB5",
 			"neighbours": [
 				{
 					"simId": "londonbridgeasc",
@@ -94,6 +99,7 @@
 		{
 			"id": "panel6",
 			"name": "Panel 6",
+			"code": "LB6",
 			"neighbours": [
 				{
 					"simId": "londonbridgeasc",
@@ -112,6 +118,7 @@
 		{
 			"id": "panel7",
 			"name": "Panel 7",
+			"code": "LB7",
 			"neighbours": [
 				{
 					"simId": "londonbridgeasc",
@@ -130,6 +137,7 @@
 		{
 			"id": "panel8",
 			"name": "Panel 8",
+			"code": "LB8",
 			"neighbours": [
 				{
 					"simId": "londonbridgeasc",
@@ -156,6 +164,7 @@
 		{
 			"id": "panel9",
 			"name": "Panel 9",
+			"code": "LB9",
 			"neighbours": [
 				{
 					"simId": "londonbridgeasc",

--- a/server/simulations/lts.json
+++ b/server/simulations/lts.json
@@ -4,6 +4,7 @@
 		{
 			"id": "london",
 			"name": "London",
+			"code": "LTL",
 			"neighbours": [
 				{
 					"simId": "gemlsouth",
@@ -30,6 +31,7 @@
 		{
 			"id": "tilbury",
 			"name": "Tilbury",
+			"code": "LTT",
 			"neighbours": [
 				{
 					"simId": "lts",
@@ -48,6 +50,7 @@
 		{
 			"id": "southend",
 			"name": "Southend",
+			"code": "LTS",
 			"neighbours": [
 				{
 					"simId": "lts",
@@ -62,6 +65,7 @@
 		{
 			"id": "crossings",
 			"name": "Crossings",
+			"code": "LTC",
 			"neighbours": [
 				{
 					"simId": "lts",

--- a/server/simulations/machynlleth.json
+++ b/server/simulations/machynlleth.json
@@ -4,6 +4,7 @@
 		{
 			"id": "west",
 			"name": "West Workstation",
+			"code": "MHW",
 			"neighbours": [
 				{
 					"simId": "machynlleth",
@@ -14,6 +15,7 @@
 		{
 			"id": "east",
 			"name": "East Workstation",
+			"code": "MHE",
 			"neighbours": [
 				{
 					"simId": "machynlleth",

--- a/server/simulations/maideast.json
+++ b/server/simulations/maideast.json
@@ -4,6 +4,7 @@
 		{
 			"id": "maidstoneeast",
 			"name": "Maidstone East",
+			"code": "MD",
 			"neighbours": [
 				{
 					"simId": "victoriaeast",

--- a/server/simulations/manchestereast.json
+++ b/server/simulations/manchestereast.json
@@ -4,6 +4,7 @@
 		{
 			"id": "dinting",
 			"name": "Dinting",
+			"code": "MED",
 			"neighbours": [
 				{
 					"simId": "manchestereast",
@@ -14,6 +15,7 @@
 		{
 			"id": "guidebridge",
 			"name": "Guide Bridge",
+			"code": "MEG",
 			"neighbours": [
 				{
 					"simId": "manchestereast",
@@ -40,6 +42,7 @@
 		{
 			"id": "stalybridge",
 			"name": "Stalybridge",
+			"code": "MES",
 			"neighbours": [
 				{
 					"simId": "manchestereast",
@@ -58,6 +61,7 @@
 		{
 			"id": "romileyjn",
 			"name": "Romiley Junction",
+			"code": "MER",
 			"neighbours": [
 				{
 					"simId": "manchestereast",
@@ -76,6 +80,7 @@
 		{
 			"id": "ashtonmossnorth",
 			"name": "Ashton Moss North",
+			"code": "MEM",
 			"neighbours": [
 				{
 					"simId": "manchestereast",
@@ -94,6 +99,7 @@
 		{
 			"id": "baguleyfoldjn",
 			"name": "Baguley Fold Junction",
+			"code": "MEB",
 			"neighbours": [
 				{
 					"simId": "manchestereast",
@@ -108,6 +114,7 @@
 		{
 			"id": "denton",
 			"name": "Denton",
+			"code": "MEE",
 			"neighbours": [
 				{
 					"simId": "manchestereast",
@@ -126,6 +133,7 @@
 		{
 			"id": "ashburys",
 			"name": "Ashburys",
+			"code": "MEA",
 			"neighbours": [
 				{
 					"simId": "manchestereast",

--- a/server/simulations/manchesternorth.json
+++ b/server/simulations/manchesternorth.json
@@ -4,6 +4,7 @@
 		{
 			"id": "west",
 			"name": "West",
+			"code": "MNW",
 			"neighbours": [
 				{
 					"simId": "manchesterpiccadilly",
@@ -22,6 +23,7 @@
 		{
 			"id": "east",
 			"name": "East",
+			"code": "MNE",
 			"neighbours": [
 				{
 					"simId": "manchesternorth",
@@ -44,6 +46,7 @@
 		{
 			"id": "vitriolworks",
 			"name": "Vitriol Works",
+			"code": "MNV",
 			"neighbours": [
 				{
 					"simId": "manchesternorth",
@@ -58,6 +61,7 @@
 		{
 			"id": "castletoneast",
 			"name": "Castleton East",
+			"code": "MNC",
 			"neighbours": [
 				{
 					"simId": "manchesternorth",
@@ -72,6 +76,7 @@
 		{
 			"id": "rochdalewest",
 			"name": "Rochdale West",
+			"code": "MNR",
 			"neighbours": [
 				{
 					"simId": "manchesternorth",

--- a/server/simulations/manchesterpiccadilly.json
+++ b/server/simulations/manchesterpiccadilly.json
@@ -4,6 +4,7 @@
 		{
 			"id": "healdgreen",
 			"name": "Heald Green",
+			"code": "MPH",
 			"neighbours": [
 				{
 					"simId": "manchesterpiccadilly",
@@ -18,6 +19,7 @@
 		{
 			"id": "longsight",
 			"name": "Longsight",
+			"code": "MPL",
 			"neighbours": [
 				{
 					"simId": "stockport",
@@ -36,6 +38,7 @@
 		{
 			"id": "piccadilly",
 			"name": "Piccadilly",
+			"code": "MPP",
 			"neighbours": [
 				{
 					"simId": "manchesterpiccadilly",
@@ -54,6 +57,7 @@
 		{
 			"id": "oxfordroad",
 			"name": "Oxford Road",
+			"code": "MPO",
 			"neighbours": [
 				{
 					"simId": "manchesterpiccadilly",
@@ -76,6 +80,7 @@
 		{
 			"id": "windsor1",
 			"name": "Windsor Bridge 1",
+			"code": "MPW1",
 			"neighbours": [
 				{
 					"simId": "manchesterpiccadilly",
@@ -102,6 +107,7 @@
 		{
 			"id": "windsor2",
 			"name": "Windsor Bridge 2",
+			"code": "MPW2",
 			"neighbours": [
 				{
 					"simId": "manchesterpiccadilly",
@@ -120,6 +126,7 @@
 		{
 			"id": "crownest",
 			"name": "Crow Nest",
+			"code": "MPC",
 			"neighbours": [
 				{
 					"simId": "manchesterpiccadilly",

--- a/server/simulations/manchestersouth.json
+++ b/server/simulations/manchestersouth.json
@@ -4,6 +4,7 @@
 		{
 			"id": "manchestersouthscc",
 			"name": "Manchester South SCC",
+			"code": "MS",
 			"neighbours": [
 				{
 					"simId": "stockport",
@@ -34,6 +35,7 @@
 		{
 			"id": "macclesfield",
 			"name": "Macclesfield",
+			"code": "MC",
 			"neighbours": [
 				{
 					"simId": "manchestersouth",

--- a/server/simulations/marylebone.json
+++ b/server/simulations/marylebone.json
@@ -4,6 +4,7 @@
 		{
 			"id": "south",
 			"name": "South",
+			"code": "MBS",
 			"neighbours": [
 				{
 					"simId": "marylebone",
@@ -26,6 +27,7 @@
 		{
 			"id": "north",
 			"name": "North",
+			"code": "MBN",
 			"neighbours": [
 				{
 					"simId": "marylebone",
@@ -52,6 +54,7 @@
 		{
 			"id": "lul",
 			"name": "London Underground Metropolitan line",
+			"code": "MBL",
 			"neighbours": [
 				{
 					"simId": "marylebone",
@@ -66,6 +69,7 @@
 		{
 			"id": "banbury",
 			"name": "Banbury",
+			"code": "MBB",
 			"neighbours": [
 				{
 					"simId": "marylebone",

--- a/server/simulations/morpeth.json
+++ b/server/simulations/morpeth.json
@@ -4,6 +4,7 @@
 		{
 			"id": "bedlington",
 			"name": "Bedlington SB",
+			"code": "MOB",
 			"neighbours": [
 				{
 					"simId": "tyneside",
@@ -14,6 +15,7 @@
 		{
 			"id": "morpeth",
 			"name": "Morpeth SB",
+			"code": "MOM",
 			"neighbours": [
 				{
 					"simId": "tyneside",
@@ -28,6 +30,7 @@
 		{
 			"id": "alnmouth",
 			"name": "Alnmouth SB",
+			"code": "MOA",
 			"neighbours": [
 				{
 					"simId": "morpeth",
@@ -42,6 +45,7 @@
 		{
 			"id": "tweedmouth",
 			"name": "Tweedmouth SB",
+			"code": "MOT",
 			"neighbours": [
 				{
 					"simId": "morpeth",

--- a/server/simulations/motherwell.json
+++ b/server/simulations/motherwell.json
@@ -50,7 +50,7 @@
 		{
 			"id": "wks3",
 			"name": "Workstation 3",
-			"code": "MW2",
+			"code": "MW3",
 			"neighbours": [
 				{
 					"simId": "motherwell",

--- a/server/simulations/motherwell.json
+++ b/server/simulations/motherwell.json
@@ -4,6 +4,7 @@
 		{
 			"id": "wks1",
 			"name": "Workstation 1",
+			"code": "MW1",
 			"neighbours": [
 				{
 					"simId": "glasgow",
@@ -26,6 +27,7 @@
 		{
 			"id": "wks2",
 			"name": "Workstation 2",
+			"code": "MW2",
 			"neighbours": [
 				{
 					"simId": "cscot",
@@ -48,6 +50,7 @@
 		{
 			"id": "wks3",
 			"name": "Workstation 3",
+			"code": "MW2",
 			"neighbours": [
 				{
 					"simId": "motherwell",
@@ -70,6 +73,7 @@
 		{
 			"id": "wks4",
 			"name": "Workstation 4",
+			"code": "MW4",
 			"neighbours": [
 				{
 					"simId": "motherwell",
@@ -88,6 +92,7 @@
 		{
 			"id": "wks5",
 			"name": "Workstation 5",
+			"code": "MW5",
 			"neighbours": [
 				{
 					"simId": "motherwell",
@@ -110,6 +115,7 @@
 		{
 			"id": "wks6",
 			"name": "Workstation 6",
+			"code": "MW6",
 			"neighbours": [
 				{
 					"simId": "motherwell",

--- a/server/simulations/nescot.json
+++ b/server/simulations/nescot.json
@@ -4,6 +4,7 @@
 		{
 			"id": "greenloaning",
 			"name": "Greenloaning",
+			"code": "ESGL",
 			"neighbours": [
 				{
 					"simId": "cscot",
@@ -18,6 +19,7 @@
 		{
 			"id": "blackford",
 			"name": "Blackford",
+			"code": "ESBF",
 			"neighbours": [
 				{
 					"simId": "nescot",
@@ -32,6 +34,7 @@
 		{
 			"id": "auchterarder",
 			"name": "Auchterarder",
+			"code": "ESAH",
 			"neighbours": [
 				{
 					"simId": "nescot",
@@ -46,6 +49,7 @@
 		{
 			"id": "hiltonjn",
 			"name": "Hilton Jn",
+			"code": "ESH",
 			"neighbours": [
 				{
 					"simId": "nescot",
@@ -64,6 +68,7 @@
 		{
 			"id": "perth",
 			"name": "Perth",
+			"code": "ESP",
 			"neighbours": [
 				{
 					"simId": "nescot",
@@ -82,6 +87,7 @@
 		{
 			"id": "barnhill",
 			"name": "Barnhill",
+			"code": "ESBH",
 			"neighbours": [
 				{
 					"simId": "nescot",
@@ -96,6 +102,7 @@
 		{
 			"id": "errol",
 			"name": "Errol",
+			"code": "ESER",
 			"neighbours": [
 				{
 					"simId": "nescot",
@@ -110,6 +117,7 @@
 		{
 			"id": "longforgan",
 			"name": "Longforgan",
+			"code": "ESLF",
 			"neighbours": [
 				{
 					"simId": "nescot",
@@ -124,6 +132,7 @@
 		{
 			"id": "dundee",
 			"name": "Dundee",
+			"code": "ESD",
 			"neighbours": [
 				{
 					"simId": "nescot",
@@ -142,6 +151,7 @@
 		{
 			"id": "taybridgesouth",
 			"name": "Tay Bridge South",
+			"code": "EST",
 			"neighbours": [
 				{
 					"simId": "nescot",
@@ -156,6 +166,7 @@
 		{
 			"id": "leuchars",
 			"name": "Leuchars",
+			"code": "ESL",
 			"neighbours": [
 				{
 					"simId": "nescot",
@@ -170,6 +181,7 @@
 		{
 			"id": "cupar",
 			"name": "Cupar",
+			"code": "ESC",
 			"neighbours": [
 				{
 					"simId": "nescot",
@@ -184,6 +196,7 @@
 		{
 			"id": "stanleyjn",
 			"name": "Stanley Jn",
+			"code": "ESS",
 			"neighbours": [
 				{
 					"simId": "nescot",
@@ -198,6 +211,7 @@
 		{
 			"id": "carnoustie",
 			"name": "Carnoustie",
+			"code": "ESCN",
 			"neighbours": [
 				{
 					"simId": "nescot",
@@ -212,6 +226,7 @@
 		{
 			"id": "arbroath",
 			"name": "Arbroath",
+			"code": "ESAB",
 			"neighbours": [
 				{
 					"simId": "nescot",
@@ -226,6 +241,7 @@
 		{
 			"id": "inverkeilor",
 			"name": "Inerkeilor",
+			"code": "ESI",
 			"neighbours": [
 				{
 					"simId": "nescot",
@@ -240,6 +256,7 @@
 		{
 			"id": "usan",
 			"name": "Usan",
+			"code": "ESU",
 			"neighbours": [
 				{
 					"simId": "nescot",
@@ -254,6 +271,7 @@
 		{
 			"id": "montrosenorth",
 			"name": "Montrose North",
+			"code": "ESM",
 			"neighbours": [
 				{
 					"simId": "nescot",
@@ -268,6 +286,7 @@
 		{
 			"id": "craigo",
 			"name": "Craigo",
+			"code": "ESCR",
 			"neighbours": [
 				{
 					"simId": "nescot",
@@ -282,6 +301,7 @@
 		{
 			"id": "laurencekirk",
 			"name": "Laurencekirk",
+			"code": "ESLK",
 			"neighbours": [
 				{
 					"simId": "nescot",
@@ -296,6 +316,7 @@
 		{
 			"id": "carmont",
 			"name": "Carmont",
+			"code": "ESCA",
 			"neighbours": [
 				{
 					"simId": "nescot",
@@ -310,6 +331,7 @@
 		{
 			"id": "stonehaven",
 			"name": "Stonehaven",
+			"code": "ESSH",
 			"neighbours": [
 				{
 					"simId": "nescot",
@@ -324,6 +346,7 @@
 		{
 			"id": "newtonhill",
 			"name": "Newtonhill",
+			"code": "ESNH",
 			"neighbours": [
 				{
 					"simId": "nescot",
@@ -338,6 +361,7 @@
 		{
 			"id": "aberdeen",
 			"name": "Aberdeen",
+			"code": "ESA",
 			"neighbours": [
 				{
 					"simId": "nescot",

--- a/server/simulations/newales.json
+++ b/server/simulations/newales.json
@@ -4,6 +4,7 @@
 		{
 			"id": "deemarshjn",
 			"name": "Dee Marsh Junction",
+			"code": "WXD",
 			"neighbours": [
 				{
 					"simId": "sandhills",
@@ -26,6 +27,7 @@
 		{
 			"id": "shotwickgf",
 			"name": "Shotwick Ground Frame",
+			"code": "WXS",
 			"neighbours": [
 				{
 					"simId": "newales",
@@ -36,6 +38,7 @@
 		{
 			"id": "penyfford",
 			"name": "Penyfford",
+			"code": "WXP",
 			"neighbours": [
 				{
 					"simId": "newales",
@@ -50,6 +53,7 @@
 		{
 			"id": "croesnewydd",
 			"name": "Croes Newydd North Fork",
+			"code": "WXN",
 			"neighbours": [
 				{
 					"simId": "newales",
@@ -68,6 +72,7 @@
 		{
 			"id": "gobowennorth",
 			"name": "Gobowen North",
+			"code": "WXG",
 			"neighbours": [
 				{
 					"simId": "newales",

--- a/server/simulations/newport.json
+++ b/server/simulations/newport.json
@@ -4,6 +4,7 @@
 		{
 			"id": "severntunnel",
 			"name": "Severn Tunnel",
+			"code": "NPS",
 			"neighbours": [
 				{
 					"simId": "gloucester",
@@ -22,6 +23,7 @@
 		{
 			"id": "magor",
 			"name": "Magor",
+			"code": "NPM",
 			"neighbours": [
 				{
 					"simId": "newport",
@@ -44,6 +46,7 @@
 		{
 			"id": "station",
 			"name": "Station",
+			"code": "NPC",
 			"neighbours": [
 				{
 					"simId": "newport",
@@ -62,6 +65,7 @@
 		{
 			"id": "parkjunction",
 			"name": "Park Junction",
+			"code": "NPP",
 			"neighbours": [
 				{
 					"simId": "newport",
@@ -72,6 +76,7 @@
 		{
 			"id": "eastusk",
 			"name": "East Usk",
+			"code": "NPU",
 			"neighbours": [
 				{
 					"simId": "newport",

--- a/server/simulations/newstreet.json
+++ b/server/simulations/newstreet.json
@@ -4,6 +4,7 @@
 		{
 			"id": "north",
 			"name": "North",
+			"code": "NSN",
 			"neighbours": [
 				{
 					"simId": "stourbridge",
@@ -34,6 +35,7 @@
 		{
 			"id": "centre",
 			"name": "Centre",
+			"code": "NSC",
 			"neighbours": [
 				{
 					"simId": "newstreet",
@@ -52,6 +54,7 @@
 		{
 			"id": "south1",
 			"name": "South 1",
+			"code": "NSS1",
 			"neighbours": [
 				{
 					"simId": "newstreet",
@@ -70,6 +73,7 @@
 		{
 			"id": "south2",
 			"name": "South 2",
+			"code": "NSS2",
 			"neighbours": [
 				{
 					"simId": "newstreet",

--- a/server/simulations/nll.json
+++ b/server/simulations/nll.json
@@ -4,6 +4,7 @@
 		{
 			"id": "richmond",
 			"name": "Richmond SB",
+			"code": "NLR",
 			"neighbours": [
 				{
 					"simId": "nll",
@@ -14,6 +15,7 @@
 		{
 			"id": "actonwellsjn",
 			"name": "Acton Wells Jn SB",
+			"code": "NLW",
 			"neighbours": [
 				{
 					"simId": "nll",
@@ -44,6 +46,7 @@
 		{
 			"id": "actoncanalwharf",
 			"name": "Acton Canal Wharf SB",
+			"code": "NLC",
 			"neighbours": [
 				{
 					"simId": "nll",
@@ -62,6 +65,7 @@
 		{
 			"id": "neasdenjn",
 			"name": "Neasden Jn SB",
+			"code": "NLN",
 			"neighbours": [
 				{
 					"simId": "nll",
@@ -80,6 +84,7 @@
 		{
 			"id": "duddinghilljn",
 			"name": "Dudding Hill Jn SB",
+			"code": "NLD",
 			"neighbours": [
 				{
 					"simId": "nll",
@@ -94,6 +99,7 @@
 		{
 			"id": "central",
 			"name": "NLL Central Workstation",
+			"code": "NLM",
 			"neighbours": [
 				{
 					"simId": "nll",
@@ -128,6 +134,7 @@
 		{
 			"id": "eastern",
 			"name": "NLL Eastern Workstation",
+			"code": "NLE",
 			"neighbours": [
 				{
 					"simId": "nll",
@@ -154,6 +161,7 @@
 		{
 			"id": "templemills",
 			"name": "Temple Mills Workstation",
+			"code": "NLT",
 			"neighbours": [
 				{
 					"simId": "nll",
@@ -180,6 +188,7 @@
 		{
 			"id": "upperholloway",
 			"name": "Upper Holloway SB",
+			"code": "NLH",
 			"neighbours": [
 				{
 					"simId": "nll",
@@ -198,6 +207,7 @@
 		{
 			"id": "harringayparkjn",
 			"name": "Harringay Park Junction SB",
+			"code": "NLP",
 			"neighbours": [
 				{
 					"simId": "nll",
@@ -216,6 +226,7 @@
 		{
 			"id": "southtottenham",
 			"name": "South Tottenham Station Junction SB",
+			"code": "NLS",
 			"neighbours": [
 				{
 					"simId": "nll",

--- a/server/simulations/north_wales_coast.json
+++ b/server/simulations/north_wales_coast.json
@@ -4,6 +4,7 @@
 		{
 			"id": "rockcliffehall",
 			"name": "Rockcliffe Hall",
+			"code": "NWS",
 			"neighbours": [
 				{
 					"simId": "chester",
@@ -18,6 +19,7 @@
 		{
 			"id": "holywelljunction",
 			"name": "Holywell Junction",
+			"code": "NWO",
 			"neighbours": [
 				{
 					"simId": "north_wales_coast",
@@ -32,6 +34,7 @@
 		{
 			"id": "mostyn",
 			"name": "Mostyn",
+			"code": "NWM",
 			"neighbours": [
 				{
 					"simId": "north_wales_coast",
@@ -46,6 +49,7 @@
 		{
 			"id": "talacre",
 			"name": "Talacre",
+			"code": "NWT",
 			"neighbours": [
 				{
 					"simId": "north_wales_coast",
@@ -60,6 +64,7 @@
 		{
 			"id": "prestatyn",
 			"name": "Prestatyn",
+			"code": "NWE",
 			"neighbours": [
 				{
 					"simId": "north_wales_coast",
@@ -74,6 +79,7 @@
 		{
 			"id": "rhyl",
 			"name": "Rhyl",
+			"code": "NWR",
 			"neighbours": [
 				{
 					"simId": "north_wales_coast",
@@ -88,6 +94,7 @@
 		{
 			"id": "abergele",
 			"name": "Abergele",
+			"code": "NWA",
 			"neighbours": [
 				{
 					"simId": "north_wales_coast",
@@ -102,6 +109,7 @@
 		{
 			"id": "llandudnojunction",
 			"name": "Llandudno Junction",
+			"code": "NWLJ",
 			"neighbours": [
 				{
 					"simId": "north_wales_coast",
@@ -124,6 +132,7 @@
 		{
 			"id": "llanwrst",
 			"name": "Llanwrst",
+			"code": "NWL",
 			"neighbours": [
 				{
 					"simId": "north_wales_coast",
@@ -134,6 +143,7 @@
 		{
 			"id": "deganwy",
 			"name": "Deganwy",
+			"code": "NWD",
 			"neighbours": [
 				{
 					"simId": "north_wales_coast",
@@ -148,6 +158,7 @@
 		{
 			"id": "llandudno",
 			"name": "Llandudno",
+			"code": "NWLS",
 			"neighbours": [
 				{
 					"simId": "north_wales_coast",
@@ -158,6 +169,7 @@
 		{
 			"id": "penmaenmawr",
 			"name": "Penmaenmawr",
+			"code": "NWP",
 			"neighbours": [
 				{
 					"simId": "north_wales_coast",
@@ -172,6 +184,7 @@
 		{
 			"id": "bangor",
 			"name": "Bangor",
+			"code": "NWB",
 			"neighbours": [
 				{
 					"simId": "north_wales_coast",
@@ -186,6 +199,7 @@
 		{
 			"id": "gaerwen",
 			"name": "Gaerwen",
+			"code": "NWG",
 			"neighbours": [
 				{
 					"simId": "north_wales_coast",
@@ -200,6 +214,7 @@
 		{
 			"id": "valley",
 			"name": "Valley",
+			"code": "NWV",
 			"neighbours": [
 				{
 					"simId": "north_wales_coast",
@@ -214,6 +229,7 @@
 		{
 			"id": "holyhead",
 			"name": "Holyhead",
+			"code": "NWH",
 			"neighbours": [
 				{
 					"simId": "north_wales_coast",

--- a/server/simulations/northkent.json
+++ b/server/simulations/northkent.json
@@ -4,6 +4,7 @@
 		{
 			"id": "northkent1",
 			"name": "North Kent 1",
+			"code": "NK1",
 			"neighbours": [
 				{
 					"simId": "northkent",
@@ -22,6 +23,7 @@
 		{
 			"id": "northkent2",
 			"name": "North Kent 2",
+			"code": "NK2",
 			"neighbours": [
 				{
 					"simId": "northkent",

--- a/server/simulations/oxford.json
+++ b/server/simulations/oxford.json
@@ -4,6 +4,7 @@
 		{
 			"id": "oxford",
 			"name": "Oxford",
+			"code": "OXF",
 			"neighbours": [
 				{
 					"simId": "marylebone",

--- a/server/simulations/oxted.json
+++ b/server/simulations/oxted.json
@@ -4,6 +4,7 @@
 		{
 			"id": "oxted",
 			"name": "Oxted",
+			"code": "OXT",
 			"neighbours": [
 				{
 					"simId": "threebridges",

--- a/server/simulations/paddington.json
+++ b/server/simulations/paddington.json
@@ -4,6 +4,7 @@
 		{
 			"id": "greenford",
 			"name": "Greenford East SB",
+			"code": "PDG",
 			"neighbours": [
 				{
 					"simId": "paddington",
@@ -22,6 +23,7 @@
 		{
 			"id": "panel2",
 			"name": "Panel 2",
+			"code": "PD2",
 			"neighbours": [
 				{
 					"simId": "slough",
@@ -40,6 +42,7 @@
 		{
 			"id": "panel1",
 			"name": "Panel 1",
+			"code": "PD1",
 			"neighbours": [
 				{
 					"simId": "paddington",

--- a/server/simulations/paisley.json
+++ b/server/simulations/paisley.json
@@ -4,6 +4,7 @@
 		{
 			"id": "panel1",
 			"name": "Panel 1",
+			"code": "PA1",
 			"neighbours": [
 				{
 					"simId": "glasgow",
@@ -18,6 +19,7 @@
 		{
 			"id": "panel2",
 			"name": "Panel 2",
+			"code": "PA2",
 			"neighbours": [
 				{
 					"simId": "paisley",
@@ -32,6 +34,7 @@
 		{
 			"id": "panel3",
 			"name": "Panel 3",
+			"code": "PA3",
 			"neighbours": [
 				{
 					"simId": "paisley",

--- a/server/simulations/peterborough.json
+++ b/server/simulations/peterborough.json
@@ -4,6 +4,7 @@
 		{
 			"id": "hitchintempsford",
 			"name": "Hitchin-Tempsford",
+			"code": "PBT",
 			"neighbours": [
 				{
 					"simId": "kingsx",
@@ -18,6 +19,7 @@
 		{
 			"id": "barfordstilton",
 			"name": "Little Barford-Stilton",
+			"code": "PHB",
 			"neighbours": [
 				{
 					"simId": "peterborough",
@@ -32,6 +34,7 @@
 		{
 			"id": "peterborough",
 			"name": "Peterborough",
+			"code": "PHP",
 			"neighbours": [
 				{
 					"simId": "peterborough",
@@ -50,6 +53,7 @@
 		{
 			"id": "newengland",
 			"name": "New England",
+			"code": "PHE",
 			"neighbours": [
 				{
 					"simId": "peterborough",
@@ -68,6 +72,7 @@
 		{
 			"id": "helpstonstoke",
 			"name": "Helpston-Stoke",
+			"code": "PHH",
 			"neighbours": [
 				{
 					"simId": "peterborough",

--- a/server/simulations/peterborough.json
+++ b/server/simulations/peterborough.json
@@ -19,7 +19,7 @@
 		{
 			"id": "barfordstilton",
 			"name": "Little Barford-Stilton",
-			"code": "PHB",
+			"code": "PBB",
 			"neighbours": [
 				{
 					"simId": "peterborough",
@@ -34,7 +34,7 @@
 		{
 			"id": "peterborough",
 			"name": "Peterborough",
-			"code": "PHP",
+			"code": "PBS",
 			"neighbours": [
 				{
 					"simId": "peterborough",
@@ -53,7 +53,7 @@
 		{
 			"id": "newengland",
 			"name": "New England",
-			"code": "PHE",
+			"code": "PBE",
 			"neighbours": [
 				{
 					"simId": "peterborough",
@@ -72,7 +72,7 @@
 		{
 			"id": "helpstonstoke",
 			"name": "Helpston-Stoke",
-			"code": "PHH",
+			"code": "PBH",
 			"neighbours": [
 				{
 					"simId": "peterborough",

--- a/server/simulations/plymouth.json
+++ b/server/simulations/plymouth.json
@@ -4,6 +4,7 @@
 		{
 			"id": "west",
 			"name": "West Workstation",
+			"code": "PLW",
 			"neighbours": [
 				{
 					"simId": "cornwall",
@@ -18,6 +19,7 @@
 		{
 			"id": "east",
 			"name": "East Workstation",
+			"code": "PLE",
 			"neighbours": [
 				{
 					"simId": "plymouth",

--- a/server/simulations/porttalbot.json
+++ b/server/simulations/porttalbot.json
@@ -4,6 +4,7 @@
 		{
 			"id": "panela",
 			"name": "Panel A",
+			"code": "PTA",
 			"neighbours": [
 				{
 					"simId": "cardiff",
@@ -26,6 +27,7 @@
 		{
 			"id": "panelb",
 			"name": "Panel B",
+			"code": "PTB",
 			"neighbours": [
 				{
 					"simId": "porttalbot",
@@ -48,6 +50,7 @@
 		{
 			"id": "panelc",
 			"name": "Panel C",
+			"code": "PTC",
 			"neighbours": [
 				{
 					"simId": "porttalbot",
@@ -62,6 +65,7 @@
 		{
 			"id": "tondu",
 			"name": "Tondu",
+			"code": "PTT",
 			"neighbours": [
 				{
 					"simId": "porttalbot",
@@ -72,6 +76,7 @@
 		{
 			"id": "neathbrecon",
 			"name": "Neath & Brecon Junction",
+			"code": "PTN",
 			"neighbours": [
 				{
 					"simId": "porttalbot",

--- a/server/simulations/preston.json
+++ b/server/simulations/preston.json
@@ -4,6 +4,7 @@
 		{
 			"id": "panela",
 			"name": "Panel A",
+			"code": "PNA",
 			"neighbours": [
 				{
 					"simId": "caldervalley",
@@ -26,6 +27,7 @@
 		{
 			"id": "panelb",
 			"name": "Panel B",
+			"code": "PNB",
 			"neighbours": [
 				{
 					"simId": "preston",
@@ -48,6 +50,7 @@
 		{
 			"id": "panelc",
 			"name": "Panel C",
+			"code": "PNC",
 			"neighbours": [
 				{
 					"simId": "preston",
@@ -70,6 +73,7 @@
 		{
 			"id": "paneld",
 			"name": "Panel D",
+			"code": "PND",
 			"neighbours": [
 				{
 					"simId": "preston",
@@ -92,6 +96,7 @@
 		{
 			"id": "daisyfield",
 			"name": "Daisyfield SB",
+			"code": "PNY",
 			"neighbours": [
 				{
 					"simId": "preston",
@@ -106,6 +111,7 @@
 		{
 			"id": "horrocksfordjn",
 			"name": "Horrocksford Jn SB",
+			"code": "PNH",
 			"neighbours": [
 				{
 					"simId": "preston",
@@ -120,6 +126,7 @@
 		{
 			"id": "midgehall",
 			"name": "Midge Hall SB",
+			"code": "PNM",
 			"neighbours": [
 				{
 					"simId": "preston",
@@ -134,6 +141,7 @@
 		{
 			"id": "rufford",
 			"name": "Rufford SB",
+			"code": "PNR",
 			"neighbours": [
 				{
 					"simId": "preston",
@@ -144,6 +152,7 @@
 		{
 			"id": "barelane",
 			"name": "Bare Lane LC",
+			"code": "PNL",
 			"neighbours": [
 				{
 					"simId": "preston",
@@ -154,6 +163,7 @@
 		{
 			"id": "carnforth",
 			"name": "Carnforth Station Junction",
+			"code": "PNF",
 			"neighbours": [
 				{
 					"simId": "preston",

--- a/server/simulations/reading.json
+++ b/server/simulations/reading.json
@@ -4,6 +4,7 @@
 		{
 			"id": "reading",
 			"name": "Reading Panel",
+			"code": "RD",
 			"neighbours": [
 				{
 					"simId": "swindid",

--- a/server/simulations/royston.json
+++ b/server/simulations/royston.json
@@ -4,6 +4,7 @@
 		{
 			"id": "royston",
 			"name": "Royston",
+			"code": "RY",
 			"neighbours": [
 				{
 					"simId": "kingsx",

--- a/server/simulations/rugbycentre.json
+++ b/server/simulations/rugbycentre.json
@@ -4,6 +4,7 @@
 		{
 			"id": "rugby",
 			"name": "Rugby",
+			"code": "RCR",
 			"neighbours": [
 				{
 					"simId": "rugbynorth",
@@ -22,6 +23,7 @@
 		{
 			"id": "northampton",
 			"name": "Northampton",
+			"code": "RCN",
 			"neighbours": [
 				{
 					"simId": "rugbycentre",

--- a/server/simulations/rugbynorth.json
+++ b/server/simulations/rugbynorth.json
@@ -4,6 +4,7 @@
 		{
 			"id": "nuneaton",
 			"name": "Nuneaton",
+			"code": "RNN",
 			"neighbours": [
 				{
 					"simId": "coventry",
@@ -30,6 +31,7 @@
 		{
 			"id": "trentvalley",
 			"name": "Trent Valley",
+			"code": "RNT",
 			"neighbours": [
 				{
 					"simId": "rugbynorth",

--- a/server/simulations/rugbysouth.json
+++ b/server/simulations/rugbysouth.json
@@ -4,6 +4,7 @@
 		{
 			"id": "bletchley",
 			"name": "Bletchley",
+			"code": "RSB",
 			"neighbours": [
 				{
 					"simId": "rugbycentre",
@@ -22,6 +23,7 @@
 		{
 			"id": "tring",
 			"name": "Tring",
+			"code": "RST",
 			"neighbours": [
 				{
 					"simId": "rugbysouth",

--- a/server/simulations/salisbury.json
+++ b/server/simulations/salisbury.json
@@ -4,6 +4,7 @@
 		{
 			"id": "salisbury",
 			"name": "Salisbury",
+			"code": "SB",
 			"neighbours": [
 				{
 					"simId": "westbury",

--- a/server/simulations/saltley.json
+++ b/server/simulations/saltley.json
@@ -4,6 +4,7 @@
 		{
 			"id": "north",
 			"name": "North",
+			"code": "SLN",
 			"neighbours": [
 				{
 					"simId": "derby",
@@ -26,6 +27,7 @@
 		{
 			"id": "centre",
 			"name": "Centre",
+			"code": "SLC",
 			"neighbours": [
 				{
 					"simId": "saltley",
@@ -48,6 +50,7 @@
 		{
 			"id": "southtop",
 			"name": "South Top",
+			"code": "SLST",
 			"neighbours": [
 				{
 					"simId": "saltley",
@@ -66,6 +69,7 @@
 		{
 			"id": "southbottom",
 			"name": "South Bottom",
+			"code": "SLSB",
 			"neighbours": [
 				{
 					"simId": "saltley",
@@ -88,6 +92,7 @@
 		{
 			"id": "stratforduponavon",
 			"name": "Stratford-Upon-Avon",
+			"code": "SLS",
 			"neighbours": [
 				{
 					"simId": "saltley",

--- a/server/simulations/sandhills.json
+++ b/server/simulations/sandhills.json
@@ -4,6 +4,7 @@
 		{
 			"id": "wirral",
 			"name": "Wirral",
+			"code": "SHW",
 			"neighbours": [
 				{
 					"simId": "sandhills",
@@ -22,6 +23,7 @@
 		{
 			"id": "northern",
 			"name": "Northern",
+			"code": "SHN",
 			"neighbours": [
 				{
 					"simId": "sandhills",

--- a/server/simulations/settlecarlisle.json
+++ b/server/simulations/settlecarlisle.json
@@ -147,7 +147,7 @@
 		{
 			"id": "howecosiding",
 			"name": "Howe & Co Siding SB",
-			"code": "SCH",
+			"code": "SCD",
 			"neighbours": [
 				{
 					"simId": "settlecarlisle",

--- a/server/simulations/settlecarlisle.json
+++ b/server/simulations/settlecarlisle.json
@@ -4,6 +4,7 @@
 		{
 			"id": "hellifield",
 			"name": "Hellifield SB",
+			"code": "SCH",
 			"neighbours": [
 				{
 					"simId": "leedsnw",
@@ -22,6 +23,7 @@
 		{
 			"id": "settlejn",
 			"name": "Settle Junction SB",
+			"code": "SCS",
 			"neighbours": [
 				{
 					"simId": "settlecarlisle",
@@ -40,6 +42,7 @@
 		{
 			"id": "bleamoor",
 			"name": "Blea Moor SB",
+			"code": "SCB",
 			"neighbours": [
 				{
 					"simId": "settlecarlisle",
@@ -54,6 +57,7 @@
 		{
 			"id": "garsdale",
 			"name": "Garsdale SB",
+			"code": "SCG",
 			"neighbours": [
 				{
 					"simId": "settlecarlisle",
@@ -68,6 +72,7 @@
 		{
 			"id": "kirkbystephen",
 			"name": "Kirkby Stephen SB",
+			"code": "SCKS",
 			"neighbours": [
 				{
 					"simId": "settlecarlisle",
@@ -82,6 +87,7 @@
 		{
 			"id": "applebynorth",
 			"name": "Appleby North SB",
+			"code": "SCA",
 			"neighbours": [
 				{
 					"simId": "settlecarlisle",
@@ -96,6 +102,7 @@
 		{
 			"id": "kirkbythore",
 			"name": "Kirkby Thore SB",
+			"code": "SCKT",
 			"neighbours": [
 				{
 					"simId": "settlecarlisle",
@@ -110,6 +117,7 @@
 		{
 			"id": "culgaith",
 			"name": "Culgaith SB",
+			"code": "SCC",
 			"neighbours": [
 				{
 					"simId": "settlecarlisle",
@@ -124,6 +132,7 @@
 		{
 			"id": "lowhousecrossing",
 			"name": "Low House Crossing SB",
+			"code": "SCL",
 			"neighbours": [
 				{
 					"simId": "settlecarlisle",
@@ -138,6 +147,7 @@
 		{
 			"id": "howecosiding",
 			"name": "Howe & Co Siding SB",
+			"code": "SCH",
 			"neighbours": [
 				{
 					"simId": "settlecarlisle",

--- a/server/simulations/sheffield.json
+++ b/server/simulations/sheffield.json
@@ -4,6 +4,7 @@
 		{
 			"id": "sheffield",
 			"name": "Sheffield",
+			"code": "SFS",
 			"neighbours": [
 				{
 					"simId": "trent",
@@ -30,6 +31,7 @@
 		{
 			"id": "rotherham1",
 			"name": "Rotherham 1",
+			"code": "SFR1",
 			"neighbours": [
 				{
 					"simId": "sheffield",
@@ -56,6 +58,7 @@
 		{
 			"id": "rotherham2",
 			"name": "Rotherham 2",
+			"code": "SFR2",
 			"neighbours": [
 				{
 					"simId": "trent",
@@ -74,6 +77,7 @@
 		{
 			"id": "beightonstnjn",
 			"name": "Beighton Station Junction",
+			"code": "SFE",
 			"neighbours": [
 				{
 					"simId": "sheffield",
@@ -88,6 +92,7 @@
 		{
 			"id": "woodhousejn",
 			"name": "Woodhouse Junction",
+			"code": "SFH",
 			"neighbours": [
 				{
 					"simId": "sheffield",
@@ -106,6 +111,7 @@
 		{
 			"id": "woodburnjn",
 			"name": "Woodburn Junction",
+			"code": "SFD",
 			"neighbours": [
 				{
 					"simId": "sheffield",
@@ -124,6 +130,7 @@
 		{
 			"id": "barnsley",
 			"name": "Barnsley",
+			"code": "SFB",
 			"neighbours": [
 				{
 					"simId": "sheffield",
@@ -142,6 +149,7 @@
 		{
 			"id": "woolleycoalsdgs",
 			"name": "Woolley Coal Sidings",
+			"code": "SFC",
 			"neighbours": [
 				{
 					"simId": "sheffield",

--- a/server/simulations/shrewsbury.json
+++ b/server/simulations/shrewsbury.json
@@ -136,7 +136,7 @@
 		{
 			"id": "whitchurch",
 			"name": "Whitchurch",
-			"code": "SRU",
+			"code": "SRT",
 			"neighbours": [
 				{
 					"simId": "shrewsbury",

--- a/server/simulations/shrewsbury.json
+++ b/server/simulations/shrewsbury.json
@@ -4,6 +4,7 @@
 		{
 			"id": "suttonbridgejn",
 			"name": "Sutton Bridge Junction",
+			"code": "SRU",
 			"neighbours": [
 				{
 					"simId": "hereford",
@@ -22,6 +23,7 @@
 		{
 			"id": "severnbridgejn",
 			"name": "Severn Bridge Junction",
+			"code": "SRE",
 			"neighbours": [
 				{
 					"simId": "shrewsbury",
@@ -40,6 +42,7 @@
 		{
 			"id": "abbeyforegate",
 			"name": "Abbey Foregate",
+			"code": "SRA",
 			"neighbours": [
 				{
 					"simId": "telfordoxley",
@@ -54,6 +57,7 @@
 		{
 			"id": "crewejunction",
 			"name": "Crewe Junction",
+			"code": "SRCJ",
 			"neighbours": [
 				{
 					"simId": "shrewsbury",
@@ -72,6 +76,7 @@
 		{
 			"id": "crewebank",
 			"name": "Crewe Bank",
+			"code": "SRCB",
 			"neighbours": [
 				{
 					"simId": "shrewsbury",
@@ -86,6 +91,7 @@
 		{
 			"id": "harlescottcrossing",
 			"name": "Harlescott Crossing",
+			"code": "SRH",
 			"neighbours": [
 				{
 					"simId": "shrewsbury",
@@ -100,6 +106,7 @@
 		{
 			"id": "wem",
 			"name": "Wem",
+			"code": "SRW",
 			"neighbours": [
 				{
 					"simId": "shrewsbury",
@@ -114,6 +121,7 @@
 		{
 			"id": "prees",
 			"name": "Prees",
+			"code": "SRP",
 			"neighbours": [
 				{
 					"simId": "shrewsbury",
@@ -128,6 +136,7 @@
 		{
 			"id": "whitchurch",
 			"name": "Whitchurch",
+			"code": "SRU",
 			"neighbours": [
 				{
 					"simId": "shrewsbury",
@@ -142,6 +151,7 @@
 		{
 			"id": "wrenbury",
 			"name": "Wrenbury",
+			"code": "SRR",
 			"neighbours": [
 				{
 					"simId": "shrewsbury",
@@ -156,6 +166,7 @@
 		{
 			"id": "nantwich",
 			"name": "Nantwich",
+			"code": "SRN",
 			"neighbours": [
 				{
 					"simId": "shrewsbury",

--- a/server/simulations/slough.json
+++ b/server/simulations/slough.json
@@ -4,6 +4,7 @@
 		{
 			"id": "west",
 			"name": "West Position",
+			"code": "SUW",
 			"neighbours": [
 				{
 					"simId": "reading",
@@ -18,6 +19,7 @@
 		{
 			"id": "east",
 			"name": "East Position",
+			"code": "SUE",
 			"neighbours": [
 				{
 					"simId": "slough",

--- a/server/simulations/southhumberside.json
+++ b/server/simulations/southhumberside.json
@@ -4,6 +4,7 @@
 		{
 			"id": "scunthorpewest",
 			"name": "Scunthorpe PSB West",
+			"code": "SMW",
 			"neighbours": [
 				{
 					"simId": "doncasternorth",
@@ -18,6 +19,7 @@
 		{
 			"id": "scunthorpeeast",
 			"name": "Scunthorpe PSB East",
+			"code": "SME",
 			"neighbours": [
 				{
 					"simId": "southhumberside",
@@ -32,6 +34,7 @@
 		{
 			"id": "gainsborough",
 			"name": "Gainsborough",
+			"code": "SMG",
 			"neighbours": [
 				{
 					"simId": "doncasterstation",
@@ -54,6 +57,7 @@
 		{
 			"id": "barnetby",
 			"name": "Barnetby",
+			"code": "SMB",
 			"neighbours": [
 				{
 					"simId": "lincoln",
@@ -76,6 +80,7 @@
 		{
 			"id": "ulcebyjn",
 			"name": "Ulceby Jn",
+			"code": "SMU",
 			"neighbours": [
 				{
 					"simId": "southhumberside",
@@ -94,6 +99,7 @@
 		{
 			"id": "grimsby",
 			"name": "Grimsby",
+			"code": "SMM",
 			"neighbours": [
 				{
 					"simId": "southhumberside",
@@ -108,6 +114,7 @@
 		{
 			"id": "immingham",
 			"name": "Immingham",
+			"code": "SMI",
 			"neighbours": [
 				{
 					"simId": "southhumberside",

--- a/server/simulations/staffordshire.json
+++ b/server/simulations/staffordshire.json
@@ -4,6 +4,7 @@
 		{
 			"id": "derbyline",
 			"name": "Derby Line",
+			"code": "STD",
 			"neighbours": [
 				{
 					"simId": "derby",
@@ -18,6 +19,7 @@
 		{
 			"id": "stokenorth",
 			"name": "Stoke North",
+			"code": "STSN",
 			"neighbours": [
 				{
 					"simId": "staffordshire",
@@ -40,6 +42,7 @@
 		{
 			"id": "stokesouth",
 			"name": "Stoke South",
+			"code": "STSS",
 			"neighbours": [
 				{
 					"simId": "staffordshire",
@@ -58,6 +61,7 @@
 		{
 			"id": "stafford",
 			"name": "Stafford",
+			"code": "STS",
 			"neighbours": [
 				{
 					"simId": "staffordshire",
@@ -80,6 +84,7 @@
 		{
 			"id": "colwich",
 			"name": "Colwich",
+			"code": "STC",
 			"neighbours": [
 				{
 					"simId": "staffordshire",

--- a/server/simulations/stockport.json
+++ b/server/simulations/stockport.json
@@ -4,6 +4,7 @@
 		{
 			"id": "edgeley1",
 			"name": "Edgeley No. 1",
+			"code": "SPE1",
 			"neighbours": [
 				{
 					"simId": "cheshirelines",
@@ -26,6 +27,7 @@
 		{
 			"id": "edgeley2",
 			"name": "Edgeley No. 2",
+			"code": "SPE2",
 			"neighbours": [
 				{
 					"simId": "stockport",
@@ -44,6 +46,7 @@
 		{
 			"id": "stockport1",
 			"name": "Stockport No. 1",
+			"code": "SPS1",
 			"neighbours": [
 				{
 					"simId": "stockport",
@@ -62,6 +65,7 @@
 		{
 			"id": "stockport2",
 			"name": "Stockport No. 2",
+			"code": "SPS2",
 			"neighbours": [
 				{
 					"simId": "stockport",
@@ -80,6 +84,7 @@
 		{
 			"id": "heatonnorrisjn",
 			"name": "Heaton Norris Jn",
+			"code": "SPH",
 			"neighbours": [
 				{
 					"simId": "stockport",

--- a/server/simulations/stourbridge.json
+++ b/server/simulations/stourbridge.json
@@ -4,6 +4,7 @@
 		{
 			"id": "stourbridgejn",
 			"name": "Stourbridge Junction",
+			"code": "SJ",
 			"neighbours": [
 				{
 					"simId": "saltley",

--- a/server/simulations/swindid.json
+++ b/server/simulations/swindid.json
@@ -4,6 +4,7 @@
 		{
 			"id": "wks1",
 			"name": "Workstation 1",
+			"code": "SW1",
 			"neighbours": [
 				{
 					"simId": "bristol",
@@ -26,6 +27,7 @@
 		{
 			"id": "wks2",
 			"name": "Workstation 2",
+			"code": "SW2",
 			"neighbours": [
 				{
 					"simId": "swindid",
@@ -44,6 +46,7 @@
 		{
 			"id": "wks3",
 			"name": "Workstation 3",
+			"code": "SW3",
 			"neighbours": [
 				{
 					"simId": "swindid",

--- a/server/simulations/telfordoxley.json
+++ b/server/simulations/telfordoxley.json
@@ -4,6 +4,7 @@
 		{
 			"id": "madeleyjn",
 			"name": "Madeley Jn.",
+			"code": "TOM",
 			"neighbours": [
 				{
 					"simId": "shrewsbury",
@@ -18,6 +19,7 @@
 		{
 			"id": "oxley",
 			"name": "Oxley",
+			"code": "TOX",
 			"neighbours": [
 				{
 					"simId": "telfordoxley",

--- a/server/simulations/threebridges.json
+++ b/server/simulations/threebridges.json
@@ -176,7 +176,7 @@
 				},
 				{
 					"simId": "guildford",
-					"panelId": "west"
+					"panelId": "guildford"
 				}
 			]
 		}

--- a/server/simulations/threebridges.json
+++ b/server/simulations/threebridges.json
@@ -4,6 +4,7 @@
 		{
 			"id": "panel1a",
 			"name": "Panel 1A",
+			"code": "TB1A",
 			"neighbours": [
 				{
 					"simId": "londonbridgeasc",
@@ -26,6 +27,7 @@
 		{
 			"id": "panel1b",
 			"name": "Panel 1B",
+			"code": "TB1B",
 			"neighbours": [
 				{
 					"simId": "threebridges",
@@ -48,6 +50,7 @@
 		{
 			"id": "panel1c",
 			"name": "Panel 1C",
+			"code": "TB1C",
 			"neighbours": [
 				{
 					"simId": "threebridges",
@@ -70,6 +73,7 @@
 		{
 			"id": "panel2",
 			"name": "Panel 2",
+			"code": "TB2",
 			"neighbours": [
 				{
 					"simId": "threebridges",
@@ -84,6 +88,7 @@
 		{
 			"id": "panel3",
 			"name": "Panel 3",
+			"code": "TB3",
 			"neighbours": [
 				{
 					"simId": "threebridges",
@@ -106,6 +111,7 @@
 		{
 			"id": "panel4",
 			"name": "Panel 4",
+			"code": "TB4",
 			"neighbours": [
 				{
 					"simId": "threebridges",
@@ -124,6 +130,7 @@
 		{
 			"id": "panel5",
 			"name": "Panel 5",
+			"code": "TB5",
 			"neighbours": [
 				{
 					"simId": "threebridges",
@@ -142,6 +149,7 @@
 		{
 			"id": "panel6",
 			"name": "Panel 6",
+			"code": "TB6",
 			"neighbours": [
 				{
 					"simId": "threebridges",
@@ -160,6 +168,7 @@
 		{
 			"id": "reigate",
 			"name": "Reigate SB",
+			"code": "TBR",
 			"neighbours": [
 				{
 					"simId": "threebridges",

--- a/server/simulations/trent.json
+++ b/server/simulations/trent.json
@@ -4,6 +4,7 @@
 		{
 			"id": "taptonjn",
 			"name": "Tapton Jn",
+			"code": "TRA",
 			"neighbours": [
 				{
 					"simId": "trent",
@@ -22,6 +23,7 @@
 		{
 			"id": "claycross",
 			"name": "Clay Cross panel",
+			"code": "TRC",
 			"neighbours": [
 				{
 					"simId": "trent",
@@ -40,6 +42,7 @@
 		{
 			"id": "erewashvalley",
 			"name": "Erewash Valley panel",
+			"code": "TRV",
 			"neighbours": [
 				{
 					"simId": "trent",
@@ -62,6 +65,7 @@
 		{
 			"id": "pinxton",
 			"name": "Pinxton SB & Sleights East SB",
+			"code": "TRP",
 			"neighbours": [
 				{
 					"simId": "trent",
@@ -76,6 +80,7 @@
 		{
 			"id": "kirkbysummit",
 			"name": "Kirkby Summit SB",
+			"code": "TRK",
 			"neighbours": [
 				{
 					"simId": "trent",
@@ -94,6 +99,7 @@
 		{
 			"id": "robinhood",
 			"name": "Robin Hood line panel",
+			"code": "TRR",
 			"neighbours": [
 				{
 					"simId": "trent",
@@ -108,6 +114,7 @@
 		{
 			"id": "nottingham",
 			"name": "Nottingham panel",
+			"code": "TRN",
 			"neighbours": [
 				{
 					"simId": "trent",
@@ -130,6 +137,7 @@
 		{
 			"id": "eastnottingham",
 			"name": "East Nottinghamshire panel",
+			"code": "TRE",
 			"neighbours": [
 				{
 					"simId": "trent",
@@ -144,6 +152,7 @@
 		{
 			"id": "trent",
 			"name": "Trent panel",
+			"code": "TRT",
 			"neighbours": [
 				{
 					"simId": "trent",
@@ -170,6 +179,7 @@
 		{
 			"id": "stapleford",
 			"name": "Stapleford & Sandiacre panel",
+			"code": "TRS",
 			"neighbours": [
 				{
 					"simId": "trent",

--- a/server/simulations/tyneside.json
+++ b/server/simulations/tyneside.json
@@ -4,6 +4,7 @@
 		{
 			"id": "darlington",
 			"name": "Darlington",
+			"code": "TYD",
 			"neighbours": [
 				{
 					"simId": "yorkns",
@@ -30,6 +31,7 @@
 		{
 			"id": "heighingtonsb",
 			"name": "Heighington Signal Box",
+			"code": "TYH",
 			"neighbours": [
 				{
 					"simId": "tyneside",
@@ -44,6 +46,7 @@
 		{
 			"id": "shildonsb",
 			"name": "Shildon Signal Box",
+			"code": "TYL",
 			"neighbours": [
 				{
 					"simId": "tyneside",
@@ -54,6 +57,7 @@
 		{
 			"id": "gateshead",
 			"name": "Gateshead",
+			"code": "TYG",
 			"neighbours": [
 				{
 					"simId": "tyneside",
@@ -72,6 +76,7 @@
 		{
 			"id": "newcastle",
 			"name": "Newcastle",
+			"code": "TYN",
 			"neighbours": [
 				{
 					"simId": "tyneside",
@@ -90,6 +95,7 @@
 		{
 			"id": "sunderland",
 			"name": "Sunderland",
+			"code": "TYS",
 			"neighbours": [
 				{
 					"simId": "tyneside",

--- a/server/simulations/victoria.json
+++ b/server/simulations/victoria.json
@@ -4,6 +4,7 @@
 		{
 			"id": "north",
 			"name": "North Signals",
+			"code": "VICN",
 			"neighbours": [
 				{
 					"simId": "victoria",
@@ -18,6 +19,7 @@
 		{
 			"id": "centre",
 			"name": "Centre Signals",
+			"code": "VICC",
 			"neighbours": [
 				{
 					"simId": "victoria",
@@ -36,6 +38,7 @@
 		{
 			"id": "south",
 			"name": "South Signals",
+			"code": "VICS",
 			"neighbours": [
 				{
 					"simId": "victoria",
@@ -50,6 +53,7 @@
 		{
 			"id": "control",
 			"name": "Line Controller",
+			"code": "VICL",
 			"neighbours": [
 				{
 					"simId": "victoria",

--- a/server/simulations/victoriac.json
+++ b/server/simulations/victoriac.json
@@ -4,6 +4,7 @@
 		{
 			"id": "panel1",
 			"name": "Panel 1",
+			"code": "VC1",
 			"neighbours": [
 				{
 					"simId": "victoriac",
@@ -22,6 +23,7 @@
 		{
 			"id": "panel2a",
 			"name": "Panel 2A",
+			"code": "VC2A",
 			"neighbours": [
 				{
 					"simId": "victoriac",
@@ -48,6 +50,7 @@
 		{
 			"id": "panel2b",
 			"name": "Panel 2B",
+			"code": "VC2B",
 			"neighbours": [
 				{
 					"simId": "victoriac",
@@ -66,6 +69,7 @@
 		{
 			"id": "panel3",
 			"name": "Panel 3",
+			"code": "VC3",
 			"neighbours": [
 				{
 					"simId": "victoriac",
@@ -92,6 +96,7 @@
 		{
 			"id": "panel4",
 			"name": "Panel 4",
+			"code": "VC4",
 			"neighbours": [
 				{
 					"simId": "victoriac",

--- a/server/simulations/victoriaeast.json
+++ b/server/simulations/victoriaeast.json
@@ -4,6 +4,7 @@
 		{
 			"id": "panel5",
 			"name": "Panel 5",
+			"code": "VE5",
 			"neighbours": [
 				{
 					"simId": "victoriac",
@@ -18,6 +19,7 @@
 		{
 			"id": "panel6",
 			"name": "Panel 6",
+			"code": "VE6",
 			"neighbours": [
 				{
 					"simId": "victoriaeast",
@@ -44,6 +46,7 @@
 		{
 			"id": "panel7",
 			"name": "Panel 7",
+			"code": "VE7",
 			"neighbours": [
 				{
 					"simId": "victoriaeast",
@@ -78,6 +81,7 @@
 		{
 			"id": "panel8",
 			"name": "Panel 8",
+			"code": "VE8",
 			"neighbours": [
 				{
 					"simId": "victoriaeast",
@@ -104,6 +108,7 @@
 		{
 			"id": "panel9",
 			"name": "Panel 9",
+			"code": "VE9",
 			"neighbours": [
 				{
 					"simId": "victoriaeast",
@@ -130,6 +135,7 @@
 		{
 			"id": "panel10a",
 			"name": "Panel 10A",
+			"code": "VE10A",
 			"neighbours": [
 				{
 					"simId": "victoriaeast",
@@ -152,6 +158,7 @@
 		{
 			"id": "panel10b",
 			"name": "Panel 10B",
+			"code": "VE10B",
 			"neighbours": [
 				{
 					"simId": "victoriaeast",

--- a/server/simulations/walsall.json
+++ b/server/simulations/walsall.json
@@ -4,6 +4,7 @@
 		{
 			"id": "walsall2006",
 			"name": "Walsall (2006)",
+			"code": "WA6",
 			"neighbours": [
 				{
 					"simId": "saltley",
@@ -26,6 +27,7 @@
 		{
 			"id": "bloxwich",
 			"name": "Bloxwich SB",
+			"code": "WAX",
 			"neighbours": [
 				{
 					"simId": "walsall",
@@ -40,6 +42,7 @@
 		{
 			"id": "hednesford",
 			"name": "Hednesford SB",
+			"code": "WAH",
 			"neighbours": [
 				{
 					"simId": "walsall",
@@ -54,6 +57,7 @@
 		{
 			"id": "brereton",
 			"name": "Brereton Sidings SB",
+			"code": "WAS",
 			"neighbours": [
 				{
 					"simId": "walsall",
@@ -64,6 +68,7 @@
 		{
 			"id": "walsall2019",
 			"name": "Walsall (2019)",
+			"code": "WA9",
 			"neighbours": [
 				{
 					"simId": "walsall",
@@ -78,6 +83,7 @@
 		{
 			"id": "bescot",
 			"name": "Bescot",
+			"code": "WAB",
 			"neighbours": [
 				{
 					"simId": "walsall",

--- a/server/simulations/warm.json
+++ b/server/simulations/warm.json
@@ -4,6 +4,7 @@
 		{
 			"id": "hackney",
 			"name": "Hackney",
+			"code": "WAK",
 			"neighbours": [
 				{
 					"simId": "livst",
@@ -22,6 +23,7 @@
 		{
 			"id": "brimsdown",
 			"name": "Brimsdown",
+			"code": "WAD",
 			"neighbours": [
 				{
 					"simId": "warm",
@@ -44,6 +46,7 @@
 		{
 			"id": "harlow",
 			"name": "Harlow",
+			"code": "WAL",
 			"neighbours": [
 				{
 					"simId": "warm",

--- a/server/simulations/warringtonpsb.json
+++ b/server/simulations/warringtonpsb.json
@@ -4,6 +4,7 @@
 		{
 			"id": "north",
 			"name": "North",
+			"code": "WRN",
 			"neighbours": [
 				{
 					"simId": "preston",
@@ -30,6 +31,7 @@
 		{
 			"id": "middle",
 			"name": "Middle",
+			"code": "WRM",
 			"neighbours": [
 				{
 					"simId": "warringtonpsb",
@@ -52,6 +54,7 @@
 		{
 			"id": "south",
 			"name": "South",
+			"code": "WRS",
 			"neighbours": [
 				{
 					"simId": "warringtonpsb",
@@ -74,6 +77,7 @@
 		{
 			"id": "arpleyjunction",
 			"name": "Arpley Junction",
+			"code": "WRJ",
 			"neighbours": [
 				{
 					"simId": "warringtonpsb",
@@ -88,6 +92,7 @@
 		{
 			"id": "astley",
 			"name": "Astley",
+			"code": "WRA",
 			"neighbours": [
 				{
 					"simId": "warringtonpsb",
@@ -102,6 +107,7 @@
 		{
 			"id": "eccles",
 			"name": "Eccles",
+			"code": "WRE",
 			"neighbours": [
 				{
 					"simId": "warringtonpsb",

--- a/server/simulations/watfordjn.json
+++ b/server/simulations/watfordjn.json
@@ -4,6 +4,7 @@
 		{
 			"id": "watfordjn",
 			"name": "Watford Junction",
+			"code": "WJ",
 			"neighbours": [
 				{
 					"simId": "rugbysouth",

--- a/server/simulations/wembley.json
+++ b/server/simulations/wembley.json
@@ -4,6 +4,7 @@
 		{
 			"id": "wembley",
 			"name": "Wembley",
+			"code": "WMW",
 			"neighbours": [
 				{
 					"simId": "watfordjn",
@@ -18,6 +19,7 @@
 		{
 			"id": "willesden",
 			"name": "Willesden",
+			"code": "WML",
 			"neighbours": [
 				{
 					"simId": "wembley",
@@ -48,6 +50,7 @@
 		{
 			"id": "camden",
 			"name": "Camden",
+			"code": "WMC",
 			"neighbours": [
 				{
 					"simId": "wembley",
@@ -70,6 +73,7 @@
 		{
 			"id": "euston",
 			"name": "Euston",
+			"code": "WME",
 			"neighbours": [
 				{
 					"simId": "wembley",

--- a/server/simulations/wembleysub.json
+++ b/server/simulations/wembleysub.json
@@ -4,6 +4,7 @@
 		{
 			"id": "wembleysub",
 			"name": "Wembley Suburban",
+			"code": "WS",
 			"neighbours": [
 				{
 					"simId": "watfordjn",

--- a/server/simulations/westbury.json
+++ b/server/simulations/westbury.json
@@ -4,6 +4,7 @@
 		{
 			"id": "reading",
 			"name": "Reading Newbury",
+			"code": "WBR",
 			"neighbours": [
 				{
 					"simId": "reading",
@@ -18,6 +19,7 @@
 		{
 			"id": "panela",
 			"name": "Panel A",
+			"code": "WBA",
 			"neighbours": [
 				{
 					"simId": "westbury",
@@ -44,6 +46,7 @@
 		{
 			"id": "panelb",
 			"name": "Panel B",
+			"code": "WBB",
 			"neighbours": [
 				{
 					"simId": "westbury",

--- a/server/simulations/westcoastway.json
+++ b/server/simulations/westcoastway.json
@@ -4,6 +4,7 @@
 		{
 			"id": "billingshurst",
 			"name": "Billingshurst SB",
+			"code": "WCB",
 			"neighbours": [
 				{
 					"simId": "horsham",
@@ -14,6 +15,7 @@
 		{
 			"id": "lancingwest",
 			"name": "Lancing Panel 2",
+			"code": "WCL",
 			"neighbours": [
 				{
 					"simId": "lancing",

--- a/server/simulations/westhampstead.json
+++ b/server/simulations/westhampstead.json
@@ -4,6 +4,7 @@
 		{
 			"id": "panel1",
 			"name": "Panel 1",
+			"code": "WH1",
 			"neighbours": [
 				{
 					"simId": "victoriaeast",
@@ -18,6 +19,7 @@
 		{
 			"id": "panel2",
 			"name": "Panel 2",
+			"code": "WH2",
 			"neighbours": [
 				{
 					"simId": "westhampstead",
@@ -40,6 +42,7 @@
 		{
 			"id": "panel3",
 			"name": "Panel 3",
+			"code": "WH3",
 			"neighbours": [
 				{
 					"simId": "westhampstead",
@@ -54,6 +57,7 @@
 		{
 			"id": "panel4",
 			"name": "Panel 4",
+			"code": "WH4",
 			"neighbours": [
 				{
 					"simId": "westhampstead",

--- a/server/simulations/westofengland.json
+++ b/server/simulations/westofengland.json
@@ -4,6 +4,7 @@
 		{
 			"id": "honiton",
 			"name": "Honiton SB",
+			"code": "BWH",
 			"neighbours": [
 				{
 					"simId": "exeter",
@@ -18,6 +19,7 @@
 		{
 			"id": "chardjn",
 			"name": "Chard Jn SB",
+			"code": "BWC",
 			"neighbours": [
 				{
 					"simId": "westofengland",
@@ -32,6 +34,7 @@
 		{
 			"id": "yeoviljn",
 			"name": "Yeovil Jn SB",
+			"code": "BWY",
 			"neighbours": [
 				{
 					"simId": "westofengland",
@@ -50,6 +53,7 @@
 		{
 			"id": "yeovilpenmill",
 			"name": "Yeovil Pen Mill SB",
+			"code": "BWP",
 			"neighbours": [
 				{
 					"simId": "westbury",
@@ -64,6 +68,7 @@
 		{
 			"id": "templecombe",
 			"name": "Templecombe SB",
+			"code": "BWT",
 			"neighbours": [
 				{
 					"simId": "westofengland",
@@ -78,6 +83,7 @@
 		{
 			"id": "gillingham",
 			"name": "Gillingham SB",
+			"code": "BWG",
 			"neighbours": [
 				{
 					"simId": "westofengland",

--- a/server/simulations/westwales.json
+++ b/server/simulations/westwales.json
@@ -4,6 +4,7 @@
 		{
 			"id": "pembrey",
 			"name": "Pembrey SB",
+			"code": "WWP",
 			"neighbours": [
 				{
 					"simId": "porttalbot",
@@ -18,6 +19,7 @@
 		{
 			"id": "kidwelly",
 			"name": "Kidwelly SB",
+			"code": "WWK",
 			"neighbours": [
 				{
 					"simId": "westwales",
@@ -32,6 +34,7 @@
 		{
 			"id": "ferryside",
 			"name": "Ferryside SB",
+			"code": "WWF",
 			"neighbours": [
 				{
 					"simId": "westwales",
@@ -46,6 +49,7 @@
 		{
 			"id": "carmarthenjn",
 			"name": "Carmarthen Jn SB",
+			"code": "WWC",
 			"neighbours": [
 				{
 					"simId": "westwales",
@@ -60,6 +64,7 @@
 		{
 			"id": "whitland",
 			"name": "Whitland SB",
+			"code": "WWW",
 			"neighbours": [
 				{
 					"simId": "westwales",
@@ -74,6 +79,7 @@
 		{
 			"id": "clarbestonroad",
 			"name": "Clarbeston Road SB",
+			"code": "WWB",
 			"neighbours": [
 				{
 					"simId": "westwales",

--- a/server/simulations/westyorkshire.json
+++ b/server/simulations/westyorkshire.json
@@ -4,6 +4,7 @@
 		{
 			"id": "horburyjn",
 			"name": "Horbury Jn",
+			"code": "WYH",
 			"neighbours": [
 				{
 					"simId": "caldervalley",
@@ -22,6 +23,7 @@
 		{
 			"id": "wakefieldkirkgate",
 			"name": "Wakefield Kirkgate",
+			"code": "WYW",
 			"neighbours": [
 				{
 					"simId": "westyorkshire",
@@ -44,6 +46,7 @@
 		{
 			"id": "castleford",
 			"name": "Castleford",
+			"code": "WYC",
 			"neighbours": [
 				{
 					"simId": "westyorkshire",
@@ -66,6 +69,7 @@
 		{
 			"id": "powcutsyke",
 			"name": "Prince of Wales & Cutsyke Boxes",
+			"code": "WYP",
 			"neighbours": [
 				{
 					"simId": "westyorkshire",
@@ -84,6 +88,7 @@
 		{
 			"id": "ferrybridge",
 			"name": "Ferrybridge",
+			"code": "WYF",
 			"neighbours": [
 				{
 					"simId": "westyorkshire",
@@ -110,6 +115,7 @@
 		{
 			"id": "milford",
 			"name": "Milford",
+			"code": "WYM",
 			"neighbours": [
 				{
 					"simId": "westyorkshire",
@@ -136,6 +142,7 @@
 		{
 			"id": "milfordwest",
 			"name": "Milford West",
+			"code": "WYS",
 			"neighbours": [
 				{
 					"simId": "westyorkshire",

--- a/server/simulations/wigan.json
+++ b/server/simulations/wigan.json
@@ -4,6 +4,7 @@
 		{
 			"id": "wiganwallgate",
 			"name": "Wigan Wallgate",
+			"code": "WIW",
 			"neighbours": [
 				{
 					"simId": "warringtonpsb",
@@ -22,6 +23,7 @@
 		{
 			"id": "rainfordjn",
 			"name": "Rainford Jnc",
+			"code": "WIR",
 			"neighbours": [
 				{
 					"simId": "wigan",
@@ -32,6 +34,7 @@
 		{
 			"id": "parbold",
 			"name": "Parbold",
+			"code": "WIP",
 			"neighbours": [
 				{
 					"simId": "wigan",
@@ -46,6 +49,7 @@
 		{
 			"id": "burscoughbridgejn",
 			"name": "Burscough Bridge Jnc",
+			"code": "WIB",
 			"neighbours": [
 				{
 					"simId": "wigan",

--- a/server/simulations/wimbledon.json
+++ b/server/simulations/wimbledon.json
@@ -93,7 +93,7 @@
 				},
 				{
 					"simId": "guildford",
-					"panelId": "east"
+					"panelId": "guildford"
 				},
 				{
 					"simId": "horsham",

--- a/server/simulations/wimbledon.json
+++ b/server/simulations/wimbledon.json
@@ -4,6 +4,7 @@
 		{
 			"id": "panel1",
 			"name": "Panel 1",
+			"code": "WI1",
 			"neighbours": [
 				{
 					"simId": "wimbledon",
@@ -22,6 +23,7 @@
 		{
 			"id": "panel2",
 			"name": "Panel 2",
+			"code": "WI2",
 			"neighbours": [
 				{
 					"simId": "wimbledon",
@@ -52,6 +54,7 @@
 		{
 			"id": "panel3",
 			"name": "Panel 3",
+			"code": "WI3",
 			"neighbours": [
 				{
 					"simId": "wimbledon",
@@ -82,6 +85,7 @@
 		{
 			"id": "panel4",
 			"name": "Panel 4",
+			"code": "WI4",
 			"neighbours": [
 				{
 					"simId": "wimbledon",
@@ -104,6 +108,7 @@
 		{
 			"id": "claphamyd",
 			"name": "Clapham Yard Panel",
+			"code": "WIC",
 			"neighbours": [
 				{
 					"simId": "wimbledon",

--- a/server/simulations/woking.json
+++ b/server/simulations/woking.json
@@ -12,7 +12,7 @@
 				},
 				{
 					"simId": "guildford",
-					"panelId": "east"
+					"panelId": "guildford"
 				},
 				{
 					"simId": "feltham",
@@ -35,7 +35,7 @@
 				},
 				{
 					"simId": "guildford",
-					"panelId": "east"
+					"panelId": "guildford"
 				},
 				{
 					"simId": "woking",
@@ -54,7 +54,7 @@
 			"neighbours": [
 				{
 					"simId": "guildford",
-					"panelId": "east"
+					"panelId": "guildford"
 				},
 				{
 					"simId": "woking",

--- a/server/simulations/woking.json
+++ b/server/simulations/woking.json
@@ -4,6 +4,7 @@
 		{
 			"id": "surbiton",
 			"name": "Surbiton",
+			"code": "WOS",
 			"neighbours": [
 				{
 					"simId": "wimbledon",
@@ -26,6 +27,7 @@
 		{
 			"id": "woking",
 			"name": "Woking",
+			"code": "WOW",
 			"neighbours": [
 				{
 					"simId": "woking",
@@ -48,6 +50,7 @@
 		{
 			"id": "aldershot",
 			"name": "Aldershot",
+			"code": "WOA",
 			"neighbours": [
 				{
 					"simId": "guildford",

--- a/server/simulations/wolverhampton.json
+++ b/server/simulations/wolverhampton.json
@@ -4,6 +4,7 @@
 		{
 			"id": "wolverhampton",
 			"name": "Wolverhampton",
+			"code": "WM",
 			"neighbours": [
 				{
 					"simId": "newstreet",

--- a/server/simulations/worksop.json
+++ b/server/simulations/worksop.json
@@ -4,6 +4,7 @@
 		{
 			"id": "thrumpton",
 			"name": "Thrumpton SB",
+			"code": "WST",
 			"neighbours": [
 				{
 					"simId": "southhumberside",
@@ -22,6 +23,7 @@
 		{
 			"id": "worksop",
 			"name": "Worksop SB",
+			"code": "WSW",
 			"neighbours": [
 				{
 					"simId": "worksop",
@@ -44,6 +46,7 @@
 		{
 			"id": "maltby",
 			"name": "Maltby Colliery SB",
+			"code": "WSM",
 			"neighbours": [
 				{
 					"simId": "worksop",
@@ -58,6 +61,7 @@
 		{
 			"id": "kiveton",
 			"name": "Kiveton Park SB",
+			"code": "WSK",
 			"neighbours": [
 				{
 					"simId": "worksop",
@@ -72,6 +76,7 @@
 		{
 			"id": "creswell",
 			"name": "Elmton & Creswell Jn SB",
+			"code": "WSE",
 			"neighbours": [
 				{
 					"simId": "worksop",
@@ -86,6 +91,7 @@
 		{
 			"id": "shirebrookjn",
 			"name": "Shirebrook Jn SB",
+			"code": "WSS",
 			"neighbours": [
 				{
 					"simId": "worksop",
@@ -104,6 +110,7 @@
 		{
 			"id": "clipstone",
 			"name": "Clipstone SB",
+			"code": "WSC",
 			"neighbours": [
 				{
 					"simId": "worksop",
@@ -118,6 +125,7 @@
 		{
 			"id": "thoresby",
 			"name": "Thoresby Colliery Jn SB",
+			"code": "WSL",
 			"neighbours": [
 				{
 					"simId": "worksop",

--- a/server/simulations/yoker.json
+++ b/server/simulations/yoker.json
@@ -4,6 +4,7 @@
 		{
 			"id": "wks1",
 			"name": "Workstation 1",
+			"code": "YR1",
 			"neighbours": [
 				{
 					"simId": "cscot",
@@ -18,6 +19,7 @@
 		{
 			"id": "wks2",
 			"name": "Workstation 2",
+			"code": "YR2",
 			"neighbours": [
 				{
 					"simId": "yoker",

--- a/server/simulations/yorkns.json
+++ b/server/simulations/yorkns.json
@@ -4,6 +4,7 @@
 		{
 			"id": "south",
 			"name": "South",
+			"code": "YKS",
 			"neighbours": [
 				{
 					"simId": "doncasternorth",
@@ -30,6 +31,7 @@
 		{
 			"id": "north",
 			"name": "North",
+			"code": "YKN",
 			"neighbours": [
 				{
 					"simId": "yorkns",
@@ -52,6 +54,7 @@
 		{
 			"id": "gascoignewood",
 			"name": "Gascoigne Wood",
+			"code": "YKG",
 			"neighbours": [
 				{
 					"simId": "yorkns",

--- a/server/src/model/panel.js
+++ b/server/src/model/panel.js
@@ -3,6 +3,7 @@
 export default class Panel {
   id;
   name;
+  code;
   player;
   /** @type {Location[]} */
   neighbours = [];
@@ -14,6 +15,7 @@ export default class Panel {
     const panel = new Panel();
     panel.id = panelData.id;
     panel.name = panelData.name;
+    panel.code = panelData.code;
     panelData.neighbours.forEach(p => panel.neighbours.push(p));
     return panelData;
   }

--- a/server/src/phonemanager.js
+++ b/server/src/phonemanager.js
@@ -63,7 +63,7 @@ export default class PhoneManager {
    * @returns {Phone}
    */
   generatePhoneForPanel(sim, panel) {
-    const phone = new Phone(sim.id +'_' + panel.id, sim.name + " " + panel.name, Phone.TYPES.FIXED, new Location(sim.id, panel.id))
+    const phone = new Phone(sim.id +'_' + panel.id, panel.code, Phone.TYPES.FIXED, new Location(sim.id, panel.id))
     this.phones.push(phone);
     return phone;
   }


### PR DESCRIPTION
Closes #64 

# Summary of changes

Defines a set of short codes for all defined panels.
Adds a doc to document all short codes in an easily searchable manner.
Short codes used to identify claimed panels in the top bar.

Also defines Eastleigh Panel 2 in basic form.

Adds a workflow to check all future PRs potentially affecting the code definitions. It checks that
1. Are all the codes defined in the documentation defined in the simulation definitions,
2. Are all the codes defined in the simulation definitions defined in the documentation,
3. Are any codes duplicated in the documentation,
4. Are any codes duplicated in the simulation definitions,

To view the exact error, you will need to examine the details of the workflow failure, and specifically view the error list under 'Run python script'.

### Please make sure you squash merge (unless if you are willing to suffer a less readable git commit history).